### PR TITLE
Low memory footprint Geolocation's implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,148 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Language:        Cpp
+    Delimiters:      
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:      
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions: 
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/gunrock/app/geo/geo_app.cu
+++ b/gunrock/app/geo/geo_app.cu
@@ -100,7 +100,8 @@ cudaError_t RunTests(
     std::string validation 	= parameters.Get<std::string>("validation");
 
     int geo_iter		= parameters.Get<int>("geo-iter");
-    util::PrintMsg("Number of iterations: " + geo_iter, !quiet_mode);
+    util::PrintMsg("Number of iterations: " 
+		    + std::to_string(geo_iter), !quiet_mode);
 
     util::Info info("geolocation", parameters, graph);
 

--- a/gunrock/app/geo/geo_app.cu
+++ b/gunrock/app/geo/geo_app.cu
@@ -20,16 +20,12 @@
 #include <gunrock/app/app_base.cuh>
 #include <gunrock/app/test_base.cuh>
 
-// <DONE> change includes
 #include <gunrock/app/geo/geo_enactor.cuh>
 #include <gunrock/app/geo/geo_test.cuh>
-// </DONE>
 
 namespace gunrock {
 namespace app {
-// <DONE> change namespace
 namespace geo {
-// </DONE>
 
 
 cudaError_t UseParameters(util::Parameters &parameters)

--- a/gunrock/app/geo/geo_app.cu
+++ b/gunrock/app/geo/geo_app.cu
@@ -6,9 +6,9 @@
 // ----------------------------------------------------------------------------
 
 /**
- * @file hello_app.cu
+ * @file geo_app.cu
  *
- * @brief Simple Gunrock Application
+ * @brief Geolocation Application
  */
 
 #include <gunrock/gunrock.h>
@@ -27,36 +27,41 @@ namespace gunrock {
 namespace app {
 namespace geo {
 
+cudaError_t UseParameters(util::Parameters &parameters) {
+  cudaError_t retval = cudaSuccess;
+  GUARD_CU(UseParameters_app(parameters));
+  GUARD_CU(UseParameters_problem(parameters));
+  GUARD_CU(UseParameters_enactor(parameters));
 
-cudaError_t UseParameters(util::Parameters &parameters)
-{
-    cudaError_t retval = cudaSuccess;
-    GUARD_CU(UseParameters_app(parameters));
-    GUARD_CU(UseParameters_problem(parameters));
-    GUARD_CU(UseParameters_enactor(parameters));
+  GUARD_CU(parameters.Use<int>(
+      "geo-iter",
+      util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+      3, "Number of iterations geolocation should run for (default=3).",
+      __FILE__, __LINE__));
 
-    GUARD_CU(parameters.Use<int>(
-        "geo-iter",
-        util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
-        3,
-        "Number of iterations geolocation should run for (default=3).",
-        __FILE__, __LINE__));
+  GUARD_CU(parameters.Use<int>(
+      "spatial-iter",
+      util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+      1000,
+      "Number of maximum iterations spatial median "
+      "kernel should run for (default=1000).",
+      __FILE__, __LINE__));
 
-    GUARD_CU(parameters.Use<bool>(
-        "geo-complete",
-        util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
-        false,
-        "Run geolocation application until all locations for all nodes are found, uses an atomic (default=false).",
-        __FILE__, __LINE__));
+  GUARD_CU(parameters.Use<bool>(
+      "geo-complete",
+      util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+      false,
+      "Run geolocation application until all locations for all nodes are "
+      "found, uses an atomic (default=false).",
+      __FILE__, __LINE__));
 
-    GUARD_CU(parameters.Use<std::string>(
-        "labels-file",
-        util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
-        "",
-        "User locations label file for geolocation app.",
-        __FILE__, __LINE__));
+  GUARD_CU(parameters.Use<std::string>(
+      "labels-file",
+      util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+      "", "User locations label file for geolocation app.", __FILE__,
+      __LINE__));
 
-    return retval;
+  return retval;
 }
 
 /**
@@ -66,170 +71,132 @@ cudaError_t UseParameters(util::Parameters &parameters)
  * @param[in]  parameters    Excution parameters
  * @param[in]  graph         Input graph
 ...
- * @param[in]  target        where to perform the app 
+ * @param[in]  target        where to perform the app
  * \return cudaError_t error message(s), if any
  */
 template <typename GraphT>
-cudaError_t RunTests(
-    util::Parameters &parameters,
-    GraphT           &graph,
-    typename GraphT::ValueT *h_latitude,
-    typename GraphT::ValueT *h_longitude,
-    // <DONE> add problem specific reference results, e.g.:
-    typename GraphT::ValueT *ref_predicted_lat,
-    typename GraphT::ValueT *ref_predicted_lon,
-    // </DONE>
-    util::Location target)
-{
-    
-    cudaError_t retval = cudaSuccess;
-       
-    typedef typename GraphT::VertexT VertexT;
-    typedef typename GraphT::ValueT  ValueT;
-    typedef typename GraphT::SizeT   SizeT;
-    typedef Problem<GraphT>          ProblemT;
-    typedef Enactor<ProblemT>        EnactorT;
+cudaError_t RunTests(util::Parameters &parameters, GraphT &graph,
+                     typename GraphT::ValueT *h_latitude,
+                     typename GraphT::ValueT *h_longitude,
+                     typename GraphT::ValueT *ref_predicted_lat,
+                     typename GraphT::ValueT *ref_predicted_lon,
+                     util::Location target) {
+  cudaError_t retval = cudaSuccess;
 
-    // CLI parameters
-    bool quiet_mode 		= parameters.Get<bool>("quiet");
-    int  num_runs   		= parameters.Get<int >("num-runs");
-    std::string validation 	= parameters.Get<std::string>("validation");
+  typedef typename GraphT::VertexT VertexT;
+  typedef typename GraphT::ValueT ValueT;
+  typedef typename GraphT::SizeT SizeT;
+  typedef Problem<GraphT> ProblemT;
+  typedef Enactor<ProblemT> EnactorT;
 
-    int geo_iter		= parameters.Get<int>("geo-iter");
-    util::PrintMsg("Number of iterations: " 
-		    + std::to_string(geo_iter), !quiet_mode);
+  // CLI parameters
+  bool quiet_mode = parameters.Get<bool>("quiet");
+  int num_runs = parameters.Get<int>("num-runs");
+  std::string validation = parameters.Get<std::string>("validation");
 
-    util::Info info("geolocation", parameters, graph);
+  int geo_iter = parameters.Get<int>("geo-iter");
+  int spatial_iter = parameters.Get<int>("spatial-iter");
 
-    util::CpuTimer cpu_timer, total_timer;
-    cpu_timer.Start(); total_timer.Start();
+  util::PrintMsg("Number of iterations: " + std::to_string(geo_iter),
+                 !quiet_mode);
 
-    // <TODO> get problem specific inputs, e.g.:
-    // std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
-    // printf("RunTests: %d srcs: src[0]=%d\n", srcs.size(), srcs[0]);
-    // </TODO>
+  util::Info info("geolocation", parameters, graph);
 
-    // <DONE> allocate problem specific host data, e.g.:
-    ValueT *h_predicted_lat = new ValueT[graph.nodes];
-    ValueT *h_predicted_lon = new ValueT[graph.nodes];
-    // </DONE>
+  util::CpuTimer cpu_timer, total_timer;
+  cpu_timer.Start();
+  total_timer.Start();
 
-    // Allocate problem and enactor on GPU, and initialize them
-    ProblemT problem(parameters);
-    EnactorT enactor;
+  // Allocate problem specific host data
+  ValueT *h_predicted_lat = new ValueT[graph.nodes];
+  ValueT *h_predicted_lon = new ValueT[graph.nodes];
 
-    util::PrintMsg("Initializing problem ... ", !quiet_mode);
+  // Allocate problem and enactor on GPU, and initialize them
+  ProblemT problem(parameters);
+  EnactorT enactor;
 
-    GUARD_CU(problem.Init(graph, target));
+  util::PrintMsg("Initializing problem ... ", !quiet_mode);
 
-    util::PrintMsg("Initializing enactor ... ", !quiet_mode);
+  GUARD_CU(problem.Init(graph, target));
 
-    GUARD_CU(enactor.Init(problem, target));
-    
-    cpu_timer.Stop();
-    parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
-    
-    for (int run_num = 0; run_num < num_runs; ++run_num) {
-        GUARD_CU(problem.Reset(
-            // <DONE> problem specific data if necessary, eg:
-            h_latitude,
-	    h_longitude,
-	    geo_iter,
-            // </DONE>
-            target
-        ));
-        GUARD_CU(enactor.Reset(
-            // <TODO> problem specific data if necessary:
-            // srcs[run_num % srcs.size()],
-            // </TODO>
-            target
-        ));
-        
-        util::PrintMsg("__________________________", !quiet_mode);
+  util::PrintMsg("Initializing enactor ... ", !quiet_mode);
 
-        cpu_timer.Start();
-        GUARD_CU(enactor.Enact(
-            // <TODO> problem specific data if necessary:
-            // srcs[run_num % srcs.size()]
-            // </TODO>
-        ));
-        cpu_timer.Stop();
-        info.CollectSingleRun(cpu_timer.ElapsedMillis());
+  GUARD_CU(enactor.Init(problem, target));
 
-        util::PrintMsg("--------------------------\nRun "
-            + std::to_string(run_num) + " elapsed: "
-            + std::to_string(cpu_timer.ElapsedMillis()) +
-            ", #iterations = "
-            + std::to_string(enactor.enactor_slices[0]
-                .enactor_stats.iteration), !quiet_mode);
-        
-        if (validation == "each") {
-            
-            GUARD_CU(problem.Extract(
-                // <DONE> problem specific data
-                h_predicted_lat,
-		h_predicted_lon
-                // </DONE>
-            ));
-            SizeT num_errors = Validate_Results(
-                parameters,
-                graph,
-                // <DONE> problem specific data
-                h_predicted_lat, h_predicted_lon,
-		ref_predicted_lat, ref_predicted_lon,
-                // </DONE>
-                false);
-        }
-    }
+  cpu_timer.Stop();
+  parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
+
+  for (int run_num = 0; run_num < num_runs; ++run_num) {
+    GUARD_CU(
+        problem.Reset(h_latitude, h_longitude, geo_iter, spatial_iter, target));
+    GUARD_CU(enactor.Reset(target));
+
+    util::PrintMsg("__________________________", !quiet_mode);
 
     cpu_timer.Start();
-    
-    GUARD_CU(problem.Extract(
-        // <DONE> problem specific data
-        h_predicted_lat,
-	h_predicted_lon
-        // </DONE>
-    ));
-    if (validation == "last") {
-        SizeT num_errors = Validate_Results(
-            parameters,
-            graph,
-            // <DONE> problem specific data
-            h_predicted_lat, h_predicted_lon,
-	    ref_predicted_lat, ref_predicted_lon,
-            // </DONE>
-            false);
+    GUARD_CU(enactor.Enact());
+    cpu_timer.Stop();
+    info.CollectSingleRun(cpu_timer.ElapsedMillis());
+
+    util::PrintMsg(
+        "--------------------------\nRun " + std::to_string(run_num) +
+            " elapsed: " + std::to_string(cpu_timer.ElapsedMillis()) +
+            ", #iterations = " +
+            std::to_string(enactor.enactor_slices[0].enactor_stats.iteration),
+        !quiet_mode);
+
+    if (validation == "each") {
+      GUARD_CU(problem.Extract(h_predicted_lat, h_predicted_lon));
+
+      SizeT num_errors =
+          Validate_Results(parameters, graph, h_predicted_lat, h_predicted_lon,
+                           ref_predicted_lat, ref_predicted_lon, false);
     }
+  }
 
-    // compute running statistics
-    // TODO: change NULL to problem specific per-vertex visited marker, e.g. h_distances
-    info.ComputeTraversalStats(enactor, (VertexT*)NULL);
-    //Display_Memory_Usage(problem);
-    #ifdef ENABLE_PERFORMANCE_PROFILING
-        //Display_Performance_Profiling(enactor);
-    #endif
+  cpu_timer.Start();
 
-    // Clean up
-    GUARD_CU(enactor.Release(target));
-    GUARD_CU(problem.Release(target));
-    // <DONE> Release problem specific data, e.g.:
-    delete[] h_predicted_lat; h_predicted_lat   = NULL;
-    delete[] h_predicted_lon; h_predicted_lon   = NULL;
-    delete[] h_latitude; h_latitude   = NULL;
-    delete[] h_longitude; h_longitude = NULL;
-    // </DONE>
-    cpu_timer.Stop(); total_timer.Stop();
+  GUARD_CU(problem.Extract(h_predicted_lat, h_predicted_lon));
 
-    info.Finalize(cpu_timer.ElapsedMillis(), total_timer.ElapsedMillis());
-    return retval;
+  if (validation == "last") {
+    SizeT num_errors =
+        Validate_Results(parameters, graph, h_predicted_lat, h_predicted_lon,
+                         ref_predicted_lat, ref_predicted_lon, false);
+  }
+
+  // compute running statistics
+  info.ComputeTraversalStats(enactor, (VertexT *)NULL);
+// Display_Memory_Usage(problem);
+#ifdef ENABLE_PERFORMANCE_PROFILING
+  // Display_Performance_Profiling(enactor);
+#endif
+
+  // Clean up
+  GUARD_CU(enactor.Release(target));
+  GUARD_CU(problem.Release(target));
+
+  delete[] h_predicted_lat;
+  h_predicted_lat = NULL;
+  delete[] h_predicted_lon;
+  h_predicted_lon = NULL;
+  delete[] h_latitude;
+  h_latitude = NULL;
+  delete[] h_longitude;
+  h_longitude = NULL;
+
+  cpu_timer.Stop();
+  total_timer.Stop();
+
+  info.Finalize(cpu_timer.ElapsedMillis(), total_timer.ElapsedMillis());
+  return retval;
 }
 
-} // namespace geo
-} // namespace app
-} // namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // ===========================================================================================
-// ========================= CODE BELOW THIS LINE NOT NEEDED FOR TESTS =======================
+// ========================= CODE BELOW THIS LINE NOT NEEDED FOR TESTS
+// =======================
 // ===========================================================================================
 
 // /*
@@ -267,7 +234,8 @@ cudaError_t RunTests(
 
 //     int num_runs = parameters.Get<int>("num-runs");
 //     // TODO: get problem specific inputs, e.g.:
-//     // std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+//     // std::vector<VertexT> srcs =
+//     parameters.Get<std::vector<VertexT>>("srcs");
 //     // int num_srcs = srcs.size();
 //     for (int run_num = 0; run_num < num_runs; ++run_num)
 //     {
@@ -293,7 +261,6 @@ cudaError_t RunTests(
 //     return total_time;
 // }
 
-
 //  * @brief Simple interface take in graph as CSR format
 //  * @param[in]  num_nodes   Number of veritces in the input graph
 //  * @param[in]  num_edges   Number of edges in the input graph
@@ -306,7 +273,7 @@ cudaError_t RunTests(
 //  * @param[out] distances   Return shortest distance to source per vertex
 //  * @param[out] preds       Return predecessors of each vertex
 //  * \return     double      Return accumulated elapsed times for all runs
- 
+
 // template <
 //     typename VertexT = int,
 //     typename SizeT   = int,
@@ -349,14 +316,15 @@ cudaError_t RunTests(
 //     // Assign pointers into gunrock graph format
 //     // TODO: change to other graph representation, if not using CSR
 //     graph.CsrT::Allocate(num_nodes, num_edges, gunrock::util::HOST);
-//     graph.CsrT::row_offsets   .SetPointer(row_offsets, num_nodes + 1, gunrock::util::HOST);
-//     graph.CsrT::column_indices.SetPointer(col_indices, num_edges, gunrock::util::HOST);
-//     graph.FromCsr(graph.csr(), true, quiet);
+//     graph.CsrT::row_offsets   .SetPointer(row_offsets, num_nodes + 1,
+//     gunrock::util::HOST); graph.CsrT::column_indices.SetPointer(col_indices,
+//     num_edges, gunrock::util::HOST); graph.FromCsr(graph.csr(), true, quiet);
 //     gunrock::graphio::LoadGraph(parameters, graph);
 
 //     // Run the Template
 //     // TODO: add problem specific outputs, e.g.
-//     double elapsed_time = gunrock_Template(parameters, graph /*, distances*/);
+//     double elapsed_time = gunrock_Template(parameters, graph /*,
+//     distances*/);
 
 //     // Cleanup
 //     graph.Release();

--- a/gunrock/app/geo/geo_d_spatial.cuh
+++ b/gunrock/app/geo/geo_d_spatial.cuh
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
 namespace gunrock {
 namespace app {
@@ -26,93 +26,78 @@ namespace geo {
 #define PI 3.141592653589793
 
 template <typename ValueT>
-__device__ __host__ ValueT radians(ValueT a){return a * PI/180;}
+__device__ __host__ ValueT radians(ValueT a) {
+  return a * PI / 180;
+}
 
 template <typename ValueT>
-__device__ __host__ ValueT degrees(ValueT a){return a * 180/PI;}
+__device__ __host__ ValueT degrees(ValueT a) {
+  return a * 180 / PI;
+}
 
 /**
  * @brief Compute the mean of all latitudues and
  *        and longitudes in a given set.
  */
 template <typename GraphT, typename ValueT, typename SizeT, typename VertexT>
-__device__ void mean(
-    GraphT   &graph,
-    util::Array1D<SizeT, ValueT> latitude,
-    util::Array1D<SizeT, ValueT> longitude,
-    SizeT     length,
-    ValueT   *mean,
-    VertexT   v)
-{
-    typedef typename GraphT::CsrT CsrT;
+__device__ void mean(GraphT &graph, util::Array1D<SizeT, ValueT> latitude,
+                     util::Array1D<SizeT, ValueT> longitude, SizeT length,
+                     ValueT *mean, VertexT v) {
+  typedef typename GraphT::CsrT CsrT;
 
-    // Calculate mean;
-    ValueT a = 0;
-    ValueT b = 0;
+  // Calculate mean;
+  ValueT a = 0;
+  ValueT b = 0;
 
-    SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
-    SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+  SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
+  SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
 
-    SizeT i = 0;
-    for(SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-    {
-	VertexT dest = graph.CsrT::GetEdgeDest(e);
-	if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-	{
-            a += latitude[dest];
-            b += longitude[dest];
-	    // printf("Locations Mean N[%u] = <%f, %f>\n", v, latitude[dest], longitude[dest]);
-	    i++;
-	}
+  SizeT len = 0;
+  for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+    VertexT dest = graph.CsrT::GetEdgeDest(e);
+    if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+      a += latitude[dest];
+      b += longitude[dest];
+      len++;
     }
+  }
 
-    SizeT len = i;
+  a /= len;
+  b /= len;
 
-    a /= len;
-    b /= len;
+  mean[0] = a;  // output latitude
+  mean[1] = b;  // output longitude
 
-    mean[0] = a; // output latitude
-    mean[1] = b; // output longitude
-
-    // printf("Locations Mean[%u] = <%f, %f>, with length = %u, currlength = %u\n", v, mean[0], mean[1], length, i);
-
-    return;
+  return;
 }
 
 /**
  * @brief Compute the midpoint of two points on a sphere.
  */
 template <typename ValueT, typename SizeT, typename VertexT>
-__device__ void midpoint(
-    ValueT p1_lat,
-    ValueT p1_lon,
-    ValueT p2_lat,
-    ValueT p2_lon,
-    util::Array1D<SizeT, ValueT> latitude,
-    util::Array1D<SizeT, ValueT> longitude,
-    VertexT v)
-{
-    // Convert to radians
-    p1_lat = radians(p1_lat);
-    p1_lon = radians(p1_lon);
-    p2_lat = radians(p2_lat);
-    p2_lon = radians(p2_lon);
+__device__ void midpoint(ValueT p1_lat, ValueT p1_lon, ValueT p2_lat,
+                         ValueT p2_lon, util::Array1D<SizeT, ValueT> latitude,
+                         util::Array1D<SizeT, ValueT> longitude, VertexT v) {
+  // Convert to radians
+  p1_lat = radians(p1_lat);
+  p1_lon = radians(p1_lon);
+  p2_lat = radians(p2_lat);
+  p2_lon = radians(p2_lon);
 
-    ValueT bx, by;
-    bx = cos(p2_lat) * cos(p2_lon - p1_lon);
-    by = cos(p2_lat) * sin(p2_lon - p1_lon);
+  ValueT bx, by;
+  bx = cos(p2_lat) * cos(p2_lon - p1_lon);
+  by = cos(p2_lat) * sin(p2_lon - p1_lon);
 
-    ValueT lat, lon;
-    lat = atan2(sin(p1_lat) + sin(p2_lat), \
-                sqrt((cos(p1_lat) + bx) * (cos(p1_lat) \
-                + bx) + by*by));
+  ValueT lat, lon;
+  lat = atan2(sin(p1_lat) + sin(p2_lat),
+              sqrt((cos(p1_lat) + bx) * (cos(p1_lat) + bx) + by * by));
 
-    lon = p1_lon + atan2(by, cos(p1_lat) + bx);
+  lon = p1_lon + atan2(by, cos(p1_lat) + bx);
 
-    latitude[v] = degrees(lat);
-    longitude[v] = degrees(lon);
+  latitude[v] = degrees(lat);
+  longitude[v] = degrees(lon);
 
-    return;
+  return;
 }
 
 /**
@@ -120,32 +105,29 @@ __device__ void midpoint(
  * surface in kilometers.
  */
 template <typename ValueT>
-__device__ __host__ ValueT haversine(
-    ValueT n_latitude,
-    ValueT n_longitude,
-    ValueT mean_latitude,
-    ValueT mean_longitude,
-    ValueT radius = 6371)
-{
-    ValueT lat, lon;
+__device__ __host__ ValueT haversine(ValueT n_latitude, ValueT n_longitude,
+                                     ValueT mean_latitude,
+                                     ValueT mean_longitude,
+                                     ValueT radius = 6371) {
+  ValueT lat, lon;
 
-    // Convert degrees to radians
-    n_latitude = radians(n_latitude);
-    n_longitude = radians(n_longitude);
-    mean_latitude = radians(mean_latitude);
-    mean_longitude = radians(mean_longitude);
+  // Convert degrees to radians
+  n_latitude = radians(n_latitude);
+  n_longitude = radians(n_longitude);
+  mean_latitude = radians(mean_latitude);
+  mean_longitude = radians(mean_longitude);
 
-    lat = mean_latitude - n_latitude;
-    lon = mean_longitude - n_longitude;
+  lat = mean_latitude - n_latitude;
+  lon = mean_longitude - n_longitude;
 
-    ValueT a = pow(sin(lat/2),2) + cos(n_latitude) *
-                cos(mean_latitude) * pow(sin(lon/2),2);
+  ValueT a = pow(sin(lat / 2), 2) +
+             cos(n_latitude) * cos(mean_latitude) * pow(sin(lon / 2), 2);
 
-    ValueT c = 2 * asin(sqrt(a));
+  ValueT c = 2 * asin(sqrt(a));
 
-    // haversine distance
-    ValueT km =  radius * c;
-    return km;
+  // haversine distance
+  ValueT km = radius * c;
+  return km;
 }
 
 /**
@@ -159,136 +141,114 @@ __device__ __host__ ValueT haversine(
  *        the mode of the set.
  */
 template <typename GraphT, typename ValueT, typename SizeT, typename VertexT>
-__device__ void spatial_median(
-    GraphT &graph,
+__device__ void spatial_median(GraphT &graph,
 
-    SizeT length,
+                               SizeT length,
 
-    util::Array1D<SizeT, ValueT> latitude,
-    util::Array1D<SizeT, ValueT> longitude,
+                               util::Array1D<SizeT, ValueT> latitude,
+                               util::Array1D<SizeT, ValueT> longitude,
 
-    VertexT v,
+                               VertexT v,
 
-    /* util::Array1D<SizeT, ValueT> D, */
-    util::Array1D<SizeT, ValueT> Dinv,
+                               util::Array1D<SizeT, ValueT> Dinv,
 
-    bool quiet,
-    ValueT eps = 1e-3,
-    SizeT max_iter = 1000)
-{
+                               bool quiet, int max_iter = 1000,
+                               ValueT eps = 1e-3) {
+  typedef typename GraphT::CsrT CsrT;
 
+  ValueT r, rinv;
+  ValueT Dinvs = 0;
 
-    typedef typename GraphT::CsrT CsrT;
+  SizeT iter_ = 0;
+  SizeT nonzeros = 0;
+  SizeT num_zeros = 0;
 
-    ValueT r, rinv;
-    ValueT Dinvs = 0;
+  // Can be done cleaner, but storing lat and long.
+  ValueT R[2], tmp[2], out[2], T[2];
+  ValueT y[2], y1[2];
 
-    SizeT iter_ = 0;
-    SizeT nonzeros = 0;
-    SizeT num_zeros = 0;
+  SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+  SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
 
-    // Can be done cleaner, but storing lat and long.
-    ValueT R[2], tmp[2], out[2], T[2];
-    ValueT y[2], y1[2];
+  // printf("Spatial median length = %u\n", length);
 
-    SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
-    SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
+  // Calculate mean of all <latitude, longitude>
+  // for all possible locations of v;
+  mean(graph, latitude, longitude, length, y, v);
 
-    // printf("Spatial median length = %u\n", length);
+  // Calculate the spatial median;
+  while (true) {
+    iter_ += 1;
+    Dinvs = 0;
+    T[0] = 0;
+    T[1] = 0;  // T.lat = 0, T.lon = 0;
+    nonzeros = 0;
 
-    // Calculate mean of all <latitude, longitude>
-    // for all possible locations of v;
-    mean (graph,
-	  latitude,
-	  longitude, 
-          length, 
-	  y, 
-	  v);
+    for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+      VertexT dest = graph.CsrT::GetEdgeDest(e);
+      if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+        ValueT Dist = 0;
+        /* D[e] */ Dist =
+            haversine(latitude[dest], longitude[dest], y[0], y[1]);
 
-    // Calculate the spatial median;
-    while (true)
-    {
-        iter_ += 1;
-        Dinvs = 0;
-        T[0] = 0; T[1] = 0; // T.lat = 0, T.lon = 0;
-        nonzeros = 0;
+        Dinv[e] = Dist /* D[e] */ == 0 ? 0 : 1 / Dist /* D[e] */;
+        nonzeros = Dist /* D[e] */ != 0 ? nonzeros + 1 : nonzeros;
+        Dinvs += Dinv[e];
+      }
+    }
 
-        for (SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-        {
-	    VertexT dest = graph.CsrT::GetEdgeDest(e);
-            if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-	    {
-		ValueT Dist = 0;
-                /* D[e] */ Dist = haversine(latitude[dest],
-                             	 longitude[dest],
-                             	 y[0], y[1]);
+    SizeT len = 0;
+    for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+      VertexT dest = graph.CsrT::GetEdgeDest(e);
+      if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+        T[0] += (Dinv[e] / Dinvs) * latitude[dest];
+        T[1] += (Dinv[e] / Dinvs) * longitude[dest];
+        len++;
+      }
+    }
 
-	        Dinv[e] = Dist /* D[e] */ == 0 ? 0 : 1 / Dist /* D[e] */;
-	        nonzeros = Dist /* D[e] */ != 0 ? nonzeros + 1 : nonzeros;
-	        Dinvs += Dinv[e];
-	    }
-	}
+    // printf("Length %u vs. len %u\n", length, len);
+    num_zeros = len - nonzeros;
+    if (num_zeros == 0) {
+      y1[0] = T[0];
+      y1[1] = T[1];
+    }
 
-	SizeT len = 0;
-	for (SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-        {
-            VertexT dest = graph.CsrT::GetEdgeDest(e);
-            if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-            {
-	        T[0] += (Dinv[e]/Dinvs) * latitude[dest];
-	        T[1] += (Dinv[e]/Dinvs) * longitude[dest];
-		len++;
-	    }
-	}
+    else if (num_zeros == len) {
+      latitude[v] = y[0];
+      longitude[v] = y[1];
+      return;
+    }
 
-	// printf("Length %u vs. len %u\n", length, len);
-	num_zeros = len - nonzeros;
-	if (num_zeros == 0)
-	{
-	    y1[0] = T[0];
-	    y1[1] = T[1];
-	}
+    else {
+      R[0] = (T[0] - y[0]) * Dinvs;
+      R[1] = (T[1] - y[1]) * Dinvs;
+      r = sqrt(R[0] * R[0] + R[1] * R[1]);
+      rinv = r == 0 ?: num_zeros / r;
 
-	else if (num_zeros == len)
-	{
-	    latitude[v] = y[0];
-	    longitude[v] = y[1];
-	    return;
-	}
+      y1[0] =
+          fmaxf(0.0f, 1 - rinv) * T[0] + fminf(1.0f, rinv) * y[0];  // latitude
+      y1[1] =
+          fmaxf(0.0f, 1 - rinv) * T[1] + fminf(1.0f, rinv) * y[1];  // longitude
+    }
 
-	else
-	{
-	    R[0] = (T[0] - y[0]) * Dinvs;
-	    R[1] = (T[1] - y[1]) * Dinvs;
-	    r = sqrt(R[0] * R[0] + R[1] * R[1]);
-	    rinv = r == 0 ? : num_zeros / r;
+    tmp[0] = y[0] - y1[0];
+    tmp[1] = y[1] - y1[1];
 
-	    y1[0] = fmaxf(0.0f, 1-rinv) * T[0]
-	          + fminf(1.0f, rinv) * y[0]; // latitude
-	    y1[1] = fmaxf(0.0f, 1-rinv) * T[1]
-	          + fminf(1.0f, rinv) * y[1]; // longitude
-	}
+    if ((sqrt(tmp[0] * tmp[0] + tmp[1] * tmp[1])) < eps || (iter_ > max_iter)) {
+      latitude[v] = y1[0];
+      longitude[v] = y1[1];
+      return;
+    }
 
-	tmp[0] = y[0] - y1[0];
-	tmp[1] = y[1] - y1[1];
-
-	if((sqrt(tmp[0] * tmp[0] + tmp[1] * tmp[1])) < eps || (iter_ > max_iter))
-	{
-	    latitude[v] = y1[0];
-	    longitude[v] = y1[1];
-	    return;
-	}
-
-	y[0] = y1[0];
-	y[1] = y1[1];
-    } // -> spatial_median while() loop
-
+    y[0] = y1[0];
+    y[1] = y1[1];
+  }  // -> spatial_median while() loop
 }
 
-
-} // namespace geo
-} // namespace app
-} // namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // Leave this at the end of the file
 // Local Variables:

--- a/gunrock/app/geo/geo_d_spatial.cuh
+++ b/gunrock/app/geo/geo_d_spatial.cuh
@@ -37,13 +37,15 @@ __device__ __host__ ValueT degrees(ValueT a){return a * 180/PI;}
  */
 template <typename GraphT, typename ValueT, typename SizeT, typename VertexT>
 __device__ void mean(
-    GraphT    graph,
+    GraphT   &graph,
     util::Array1D<SizeT, ValueT> latitude,
     util::Array1D<SizeT, ValueT> longitude,
     SizeT     length,
-    ValueT  * mean,
+    ValueT   *mean,
     VertexT   v)
 {
+    typedef typename GraphT::CsrT CsrT;
+
     // Calculate mean;
     ValueT a = 0;
     ValueT b = 0;
@@ -158,7 +160,7 @@ __device__ __host__ ValueT haversine(
  */
 template <typename GraphT, typename ValueT, typename SizeT, typename VertexT>
 __device__ void spatial_median(
-    GraphT graph,
+    GraphT &graph,
 
     SizeT length,
 
@@ -174,6 +176,9 @@ __device__ void spatial_median(
     ValueT eps = 1e-3,
     SizeT max_iter = 1000)
 {
+
+
+    typedef typename GraphT::CsrT CsrT;
 
     ValueT r, rinv;
     ValueT Dinvs = 0;

--- a/gunrock/app/geo/geo_enactor.cuh
+++ b/gunrock/app/geo/geo_enactor.cuh
@@ -167,8 +167,8 @@ struct GEOIterationLoop : public IterationLoopBase
                 for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
                     VertexT u = graph.CsrT::GetEdgeDest(e);
                     if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
-			neighbor_lat[i] = latitude[u]; 	        // last valid latitude
-			neighbor_lon[i] = longitude[u]; 	// last valid longitude
+			neighbor_lat[i%2] = latitude[u]; 	        // last valid latitude
+			neighbor_lon[i%2] = longitude[u]; 	// last valid longitude
                         i++;
          	    }
                 }

--- a/gunrock/app/geo/geo_enactor.cuh
+++ b/gunrock/app/geo/geo_enactor.cuh
@@ -18,10 +18,9 @@
 #include <gunrock/app/enactor_iteration.cuh>
 #include <gunrock/app/enactor_loop.cuh>
 #include <gunrock/oprtr/oprtr.cuh>
- 
-#include <gunrock/app/geo/geo_problem.cuh>
-#include <gunrock/app/geo/geo_d_spatial.cuh>
 
+#include <gunrock/app/geo/geo_d_spatial.cuh>
+#include <gunrock/app/geo/geo_problem.cuh>
 
 namespace gunrock {
 namespace app {
@@ -29,15 +28,14 @@ namespace geo {
 
 /**
  * @brief Speciflying parameters for Geo Enactor
- * @param parameters The util::Parameter<...> structure holding all parameter info
- * \return cudaError_t error message(s), if any
+ * @param parameters The util::Parameter<...> structure holding all parameter
+ * info \return cudaError_t error message(s), if any
  */
-cudaError_t UseParameters_enactor(util::Parameters &parameters)
-{
-    cudaError_t retval = cudaSuccess;
-    GUARD_CU(app::UseParameters_enactor(parameters));
-    
-    return retval;
+cudaError_t UseParameters_enactor(util::Parameters &parameters) {
+  cudaError_t retval = cudaSuccess;
+  GUARD_CU(app::UseParameters_enactor(parameters));
+
+  return retval;
 }
 
 /**
@@ -45,287 +43,231 @@ cudaError_t UseParameters_enactor(util::Parameters &parameters)
  * @tparam EnactorT Type of enactor
  */
 template <typename EnactorT>
-struct GEOIterationLoop : public IterationLoopBase
-    <EnactorT, Use_FullQ | Push
-    // <TODO>if needed, stack more option, e.g.:
-    // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
-    // Update_Predecessors : 0x0)
-    // </TODO>
-    >
-{
-    typedef typename EnactorT::VertexT VertexT;
-    typedef typename EnactorT::SizeT   SizeT;
-    typedef typename EnactorT::ValueT  ValueT;
-    typedef typename EnactorT::Problem::GraphT::CsrT CsrT;
-    typedef typename EnactorT::Problem::GraphT::GpT  GpT;
-    
-    typedef IterationLoopBase
-        <EnactorT, Use_FullQ | Push
-        // <TODO> add the same options as in template parameters here, e.g.:
-        // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
-        // Update_Predecessors : 0x0)
-        // </TODO>
-        > BaseIterationLoop;
+struct GEOIterationLoop : public IterationLoopBase<EnactorT, Use_FullQ | Push> {
+  typedef typename EnactorT::VertexT VertexT;
+  typedef typename EnactorT::SizeT SizeT;
+  typedef typename EnactorT::ValueT ValueT;
+  typedef typename EnactorT::Problem::GraphT::CsrT CsrT;
+  typedef typename EnactorT::Problem::GraphT::GpT GpT;
 
-    GEOIterationLoop() : BaseIterationLoop() {}
+  typedef IterationLoopBase<EnactorT, Use_FullQ | Push> BaseIterationLoop;
 
-    /**
-     * @brief Core computation of Geo, one iteration
-     * @param[in] peer_ Which GPU peers to work on, 0 means local
-     * \return cudaError_t error message(s), if any
-     */
-    cudaError_t Core(int peer_ = 0)
-    {
-        // --
-        // Alias variables
-        
-        auto &data_slice = this -> enactor ->
-            problem -> data_slices[this -> gpu_num][0];
-        
-        auto &enactor_slice = this -> enactor ->
-            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
-        
-        auto &enactor_stats    = enactor_slice.enactor_stats;
-        auto &graph            = data_slice.sub_graph[0];
-        auto &frontier         = enactor_slice.frontier;
-        auto &oprtr_parameters = enactor_slice.oprtr_parameters;
-        auto &retval           = enactor_stats.retval;
-        auto &iteration        = enactor_stats.iteration;
+  GEOIterationLoop() : BaseIterationLoop() {}
 
-        auto &latitude	       = data_slice.latitude;
-	auto &longitude	       = data_slice.longitude;
+  /**
+   * @brief Core computation of Geo, one iteration
+   * @param[in] peer_ Which GPU peers to work on, 0 means local
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Core(int peer_ = 0) {
+    // --
+    // Alias variables
 
-	auto &active	       = data_slice.active;
-	auto &geo_iter	       = data_slice.geo_iter;
+    auto &data_slice = this->enactor->problem->data_slices[this->gpu_num][0];
 
-	auto &geo_complete     = data_slice.geo_complete;
+    auto &enactor_slice =
+        this->enactor
+            ->enactor_slices[this->gpu_num * this->enactor->num_gpus + peer_];
 
-	/* auto &D	       = data_slice.D; */
-	auto &Dinv	       = data_slice.Dinv;
+    auto &enactor_stats = enactor_slice.enactor_stats;
+    auto &graph = data_slice.sub_graph[0];
+    auto &frontier = enactor_slice.frontier;
+    auto &oprtr_parameters = enactor_slice.oprtr_parameters;
+    auto &retval = enactor_stats.retval;
+    auto &iteration = enactor_stats.iteration;
 
-	auto &valid_locations  = data_slice.valid_locations;
+    auto &latitude = data_slice.latitude;
+    auto &longitude = data_slice.longitude;
 
-	util::Location target = util::DEVICE;
- 
-        // --
-        // Define operations
+    auto &active = data_slice.active;
+    auto &geo_iter = data_slice.geo_iter;
+    auto &spatial_iter = data_slice.spatial_iter;
 
-	auto gather_op = [
-	    graph,
-	    latitude,
-	    longitude,
-	    valid_locations
-	] __host__ __device__ (VertexT *v_q, const SizeT &pos) {
+    auto &geo_complete = data_slice.geo_complete;
 
-	    VertexT v 		= v_q[pos];
-	    SizeT start_edge 	= graph.CsrT::GetNeighborListOffset(v);
-	    SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+    auto &Dinv = data_slice.Dinv;
 
-	    SizeT i 		= 0;
+    auto &valid_locations = data_slice.valid_locations;
 
-	    for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
-		VertexT u = graph.CsrT::GetEdgeDest(e);
-		if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
-		    // gather locations from neighbors	
-		    i++;
-		}
-	    }
-	    valid_locations[v] = i;
+    util::Location target = util::DEVICE;
 
-	};
+    // --
+    // Define operations
 
+    auto gather_op =
+        [graph, latitude, longitude, valid_locations] __host__ __device__(
+            VertexT * v_q, const SizeT &pos) {
+          VertexT v = v_q[pos];
+          SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
+          SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
 
-	/**
-	 * @brief Compute "center" of a set of points.
-	 *
-	 *      For set X ->
-	 *        if points == 1; center = point;
-	 *        if points == 2; center = midpoint;
-	 *        if points > 2; center = spatial median;
-	 */
-	auto spatial_center_op =  [
-	    graph,
-	    latitude,
-	    longitude,
-	    // valid_locations,
-	    // D, 
-	    Dinv
-	] __host__ __device__ (VertexT *v_q, const SizeT &pos) {
-	    
-	    VertexT v               = v_q[pos];
+          SizeT i = 0;
 
-	    // if no predicted location, and neighbor locations exists
-            // Custom spatial center kernel for geolocation
-            if (!util::isValid(latitude[v]) && !util::isValid(longitude[v])) {
-
-	        SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
-                SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
-
-                SizeT i = 0;
-		ValueT neighbor_lat[2], neighbor_lon[2]; // for length <=2 use registers
-
-                for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
-                    VertexT u = graph.CsrT::GetEdgeDest(e);
-                    if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
-			neighbor_lat[i%2] = latitude[u]; 	        // last valid latitude
-			neighbor_lon[i%2] = longitude[u]; 	// last valid longitude
-                        i++;
-         	    }
-                }
-
-		SizeT valid_neighbors = i;
-		// printf("Valid Lengths[%u] = %u\n", v, valid_locations[v]);
-
-		// If one location found, point at that location
-		if (valid_neighbors == 1) {
-		    latitude[v] = neighbor_lat[0];
-		    longitude[v] = neighbor_lon[0];
-		    return;
-		}
-
-	        // If two locations found, compute a midpoint
-		else if (valid_neighbors == 2) {
-		    midpoint(
-                 	neighbor_lat[0],
-			neighbor_lon[0],
-			neighbor_lat[1],
-                        neighbor_lon[1],
-			latitude,
-                 	longitude,
-                 	v);
-             	    return;
-		}
-		
-		// if locations more than 2, compute spatial
-                // median.
-		else if (valid_neighbors > 2) {
-		    spatial_median (
-				graph,
-				valid_neighbors,
-				latitude,
-				longitude,			
-				v,
-				Dinv,
-				false);
-		}
-		
-		// if no valid locations are found
-		else {
-		    latitude[v] = util::PreDefinedValues<ValueT>::InvalidValue;
-		    longitude[v] = util::PreDefinedValues<ValueT>::InvalidValue;
-		}
-
-	    } // -- median calculation.
-	};
-
-	auto status_op = [
-	    latitude,
-	    longitude,
-	    active
-	] __host__ __device__ (VertexT *v_q, const SizeT &pos) {
-
-	    VertexT v           = v_q[pos];
-	    if (util::isValid(latitude[v]) && util::isValid(longitude[v])) {
-		// TODO: Confirm atomic usage:
-		// I don't think I need an atomic
-		// here, it doesn't matter who reaches the int
-		// first, as long as it gets to add 1 to it.
-		atomicAdd(&active[0], 1);
-	    }
-	};
-
-	// Run --
-        // GUARD_CU(frontier.V_Q()->ForAll(
-        //    gather_op, frontier.queue_length,
-        //    util::DEVICE, oprtr_parameters.stream));
-
-	GUARD_CU(frontier.V_Q()->ForAll(
-	    spatial_center_op, frontier.queue_length,
-	    util::DEVICE, oprtr_parameters.stream));
-
-
-	if (geo_complete) {
-	    GUARD_CU(frontier.V_Q()->ForAll(
-		status_op, frontier.queue_length,
-		util::DEVICE, oprtr_parameters.stream));
-
-            GUARD_CU(data_slice.active .SetPointer(&data_slice.active_, sizeof(SizeT), util::HOST));
-            GUARD_CU(data_slice.active .Move(util::DEVICE, util::HOST));
-	} 
-
-        return retval;
-    }
-
-    /**
-     * @brief Routine to combine received data and local data
-     * @tparam NUM_VERTEX_ASSOCIATES Number of data associated with each transmition item, typed VertexT
-     * @tparam NUM_VALUE__ASSOCIATES Number of data associated with each transmition item, typed ValueT
-     * @param  received_length The numver of transmition items received
-     * @param[in] peer_ which peer GPU the data came from
-     * \return cudaError_t error message(s), if any
-     */
-    template <
-        int NUM_VERTEX_ASSOCIATES,
-        int NUM_VALUE__ASSOCIATES>
-    cudaError_t ExpandIncoming(SizeT &received_length, int peer_)
-    {
-        
-        // ================ INCOMPLETE TEMPLATE - MULTIGPU ====================
-        
-        auto &data_slice    = this -> enactor ->
-            problem -> data_slices[this -> gpu_num][0];
-        auto &enactor_slice = this -> enactor ->
-            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
-        //auto iteration = enactor_slice.enactor_stats.iteration;
-        // TODO: add problem specific data alias here, e.g.:
-        // auto         &distances          =   data_slice.distances;
-
-        auto expand_op = [
-        // TODO: pass data used by the lambda, e.g.:
-        // distances
-        ] __host__ __device__(
-            VertexT &key, const SizeT &in_pos,
-            VertexT *vertex_associate_ins,
-            ValueT  *value__associate_ins) -> bool
-        {
-            // TODO: fill in the lambda to combine received and local data, e.g.:
-            // ValueT in_val  = value__associate_ins[in_pos];
-            // ValueT old_val = atomicMin(distances + key, in_val);
-            // if (old_val <= in_val)
-            //     return false;
-            return true;
+          for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+            VertexT u = graph.CsrT::GetEdgeDest(e);
+            if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
+              // gather locations from neighbors
+              i++;
+            }
+          }
+          valid_locations[v] = i;
         };
 
-        cudaError_t retval = BaseIterationLoop:: template ExpandIncomingBase
-            <NUM_VERTEX_ASSOCIATES, NUM_VALUE__ASSOCIATES>
-            (received_length, peer_, expand_op);
-        return retval;
+    /**
+     * @brief Compute "center" of a set of points.
+     *
+     *      For set X ->
+     *        if points == 1; center = point;
+     *        if points == 2; center = midpoint;
+     *        if points > 2; center = spatial median;
+     */
+    auto spatial_center_op =
+        [graph, latitude, longitude, Dinv, spatial_iter] __host__ __device__(
+            VertexT * v_q, const SizeT &pos) {
+          VertexT v = v_q[pos];
+
+          // if no predicted location, and neighbor locations exists
+          // Custom spatial center kernel for geolocation
+          if (!util::isValid(latitude[v]) && !util::isValid(longitude[v])) {
+            SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
+            SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+
+            SizeT i = 0;
+            ValueT neighbor_lat[2],
+                neighbor_lon[2];  // for length <=2 use registers
+
+            for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+              VertexT u = graph.CsrT::GetEdgeDest(e);
+              if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
+                neighbor_lat[i % 2] = latitude[u];   // last valid latitude
+                neighbor_lon[i % 2] = longitude[u];  // last valid longitude
+                i++;
+              }
+            }
+
+            SizeT valid_neighbors = i;
+            // printf("Valid Lengths[%u] = %u\n", v, valid_locations[v]);
+
+            // If one location found, point at that location
+            if (valid_neighbors == 1) {
+              latitude[v] = neighbor_lat[0];
+              longitude[v] = neighbor_lon[0];
+              return;
+            }
+
+            // If two locations found, compute a midpoint
+            else if (valid_neighbors == 2) {
+              midpoint(neighbor_lat[0], neighbor_lon[0], neighbor_lat[1],
+                       neighbor_lon[1], latitude, longitude, v);
+              return;
+            }
+
+            // if locations more than 2, compute spatial
+            // median.
+            else if (valid_neighbors > 2) {
+              spatial_median(graph, valid_neighbors, latitude, longitude, v,
+                             Dinv, false, spatial_iter);
+            }
+
+            // if no valid locations are found
+            else {
+              latitude[v] = util::PreDefinedValues<ValueT>::InvalidValue;
+              longitude[v] = util::PreDefinedValues<ValueT>::InvalidValue;
+            }
+
+          }  // -- median calculation.
+        };
+
+    auto status_op = [latitude, longitude, active] __host__ __device__(
+                         VertexT * v_q, const SizeT &pos) {
+      VertexT v = v_q[pos];
+      if (util::isValid(latitude[v]) && util::isValid(longitude[v])) {
+        atomicAdd(&active[0], 1);
+      }
+    };
+
+    // Run --
+    // GUARD_CU(frontier.V_Q()->ForAll(
+    //    gather_op, frontier.queue_length,
+    //    util::DEVICE, oprtr_parameters.stream));
+
+    GUARD_CU(frontier.V_Q()->ForAll(spatial_center_op, frontier.queue_length,
+                                    util::DEVICE, oprtr_parameters.stream));
+
+    if (geo_complete) {
+      GUARD_CU(frontier.V_Q()->ForAll(status_op, frontier.queue_length,
+                                      util::DEVICE, oprtr_parameters.stream));
+
+      GUARD_CU(data_slice.active.SetPointer(&data_slice.active_, sizeof(SizeT),
+                                            util::HOST));
+      GUARD_CU(data_slice.active.Move(util::DEVICE, util::HOST));
     }
 
-    bool Stop_Condition(int gpu_num = 0) 
-    {
-        auto &enactor_slice = this -> enactor -> enactor_slices[0];
-        auto &enactor_stats = enactor_slice.enactor_stats;
-        auto &data_slice    = this -> enactor -> problem -> data_slices[this -> gpu_num][0];
-	auto &graph 	    = data_slice.sub_graph[0];
+    return retval;
+  }
 
-        auto iter 	    = enactor_stats.iteration;
+  /**
+   * @brief Routine to combine received data and local data
+   * @tparam NUM_VERTEX_ASSOCIATES Number of data associated with each
+   * transmition item, typed VertexT
+   * @tparam NUM_VALUE__ASSOCIATES Number of data associated with each
+   * transmition item, typed ValueT
+   * @param  received_length The numver of transmition items received
+   * @param[in] peer_ which peer GPU the data came from
+   * \return cudaError_t error message(s), if any
+   */
+  template <int NUM_VERTEX_ASSOCIATES, int NUM_VALUE__ASSOCIATES>
+  cudaError_t ExpandIncoming(SizeT &received_length, int peer_) {
+    // ================ INCOMPLETE TEMPLATE - MULTIGPU ====================
 
-	// Anymore work to do?
-	// printf("Predictions active in Stop: %u vs. needed %u.\n", data_slice.active_, graph.nodes);	
-	if (data_slice.geo_complete) {
-	    if(data_slice.active_ >= graph.nodes)
-	        return true;
-	} else {
-	    if(iter >= data_slice.geo_iter)
-		return true;
-	}
+    auto &data_slice = this->enactor->problem->data_slices[this->gpu_num][0];
+    auto &enactor_slice =
+        this->enactor
+            ->enactor_slices[this->gpu_num * this->enactor->num_gpus + peer_];
 
-	// else, keep running
-        return false;
+    auto expand_op = [
+                         // TODO: pass data used by the lambda, e.g.:
+                         // distances
+    ] __host__ __device__(VertexT & key, const SizeT &in_pos,
+                          VertexT *vertex_associate_ins,
+                          ValueT *value__associate_ins) -> bool {
+      // TODO: fill in the lambda to combine received and local data, e.g.:
+      // ValueT in_val  = value__associate_ins[in_pos];
+      // ValueT old_val = atomicMin(distances + key, in_val);
+      // if (old_val <= in_val)
+      //     return false;
+      return true;
+    };
+
+    cudaError_t retval =
+        BaseIterationLoop::template ExpandIncomingBase<NUM_VERTEX_ASSOCIATES,
+                                                       NUM_VALUE__ASSOCIATES>(
+            received_length, peer_, expand_op);
+    return retval;
+  }
+
+  bool Stop_Condition(int gpu_num = 0) {
+    auto &enactor_slice = this->enactor->enactor_slices[0];
+    auto &enactor_stats = enactor_slice.enactor_stats;
+    auto &data_slice = this->enactor->problem->data_slices[this->gpu_num][0];
+    auto &graph = data_slice.sub_graph[0];
+
+    auto iter = enactor_stats.iteration;
+
+    // Anymore work to do?
+    // printf("Predictions active in Stop: %u vs. needed %u.\n",
+    // data_slice.active_, graph.nodes);
+    if (data_slice.geo_complete) {
+      if (data_slice.active_ >= graph.nodes) return true;
+    } else {
+      if (iter >= data_slice.geo_iter) return true;
     }
 
-}; // end of GEOIteration
+    // else, keep running
+    return false;
+  }
+
+};  // end of GEOIteration
 
 /**
  * @brief Geolocation enactor class.
@@ -333,191 +275,158 @@ struct GEOIterationLoop : public IterationLoopBase
  * @tparam ARRAY_FLAG Flags for util::Array1D used in the enactor
  * @tparam cudaHostRegisterFlag Flags for util::Array1D used in the enactor
  */
-template <
-    typename _Problem,
-    util::ArrayFlag ARRAY_FLAG = util::ARRAY_NONE,
-    unsigned int cudaHostRegisterFlag = cudaHostRegisterDefault>
-class Enactor :
-    public EnactorBase<
-        typename _Problem::GraphT,
-        typename _Problem::GraphT::VertexT, // TODO: change to other label types used for the operators, e.g.: typename _Problem::LabelT,
-        typename _Problem::GraphT::ValueT,  // TODO: change to other value types used for inter GPU communication, e.g.: typename _Problem::ValueT,
-        ARRAY_FLAG, cudaHostRegisterFlag>
-{
-public:
-    typedef _Problem                   Problem ;
-    typedef typename Problem::SizeT    SizeT   ;
-    typedef typename Problem::VertexT  VertexT ;
-    typedef typename Problem::GraphT   GraphT  ;
-    typedef typename GraphT::VertexT   LabelT  ;
-    typedef typename GraphT::ValueT    ValueT  ;
-    typedef EnactorBase<GraphT, LabelT, ValueT, ARRAY_FLAG, cudaHostRegisterFlag>
-        BaseEnactor;
-    typedef Enactor<Problem, ARRAY_FLAG, cudaHostRegisterFlag> 
-        EnactorT;
-    typedef GEOIterationLoop<EnactorT> 
-        IterationT;
+template <typename _Problem, util::ArrayFlag ARRAY_FLAG = util::ARRAY_NONE,
+          unsigned int cudaHostRegisterFlag = cudaHostRegisterDefault>
+class Enactor
+    : public EnactorBase<
+          typename _Problem::GraphT, typename _Problem::GraphT::VertexT,
+          typename _Problem::GraphT::ValueT, ARRAY_FLAG, cudaHostRegisterFlag> {
+ public:
+  typedef _Problem Problem;
+  typedef typename Problem::SizeT SizeT;
+  typedef typename Problem::VertexT VertexT;
+  typedef typename Problem::GraphT GraphT;
+  typedef typename GraphT::VertexT LabelT;
+  typedef typename GraphT::ValueT ValueT;
+  typedef EnactorBase<GraphT, LabelT, ValueT, ARRAY_FLAG, cudaHostRegisterFlag>
+      BaseEnactor;
+  typedef Enactor<Problem, ARRAY_FLAG, cudaHostRegisterFlag> EnactorT;
+  typedef GEOIterationLoop<EnactorT> IterationT;
 
-    Problem *problem;
-    IterationT *iterations;
+  Problem *problem;
+  IterationT *iterations;
 
-    /**
-     * @brief geo constructor
-     */
-    Enactor() :
-        BaseEnactor("Geolocation"),
-        problem    (NULL  )
-    {
-        // <TODO> change according to algorithmic needs
-        this -> max_num_vertex_associates = 0;
-        this -> max_num_value__associates = 1;
-        // </TODO>
+  /**
+   * @brief geo constructor
+   */
+  Enactor() : BaseEnactor("Geolocation"), problem(NULL) {
+    this->max_num_vertex_associates = 0;
+    this->max_num_value__associates = 1;
+  }
+
+  /**
+   * @brief geo destructor
+   */
+  virtual ~Enactor() { /*Release();*/
+  }
+
+  /*
+   * @brief Releasing allocated memory space
+   * @param target The location to release memory from
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Release(util::Location target = util::LOCATION_ALL) {
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(BaseEnactor::Release(target));
+    delete[] iterations;
+    iterations = NULL;
+    problem = NULL;
+    return retval;
+  }
+
+  /**
+   * @brief Initialize the problem.
+   * @param[in] problem The problem object.
+   * @param[in] target Target location of data
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Init(Problem &problem, util::Location target = util::DEVICE) {
+    cudaError_t retval = cudaSuccess;
+    this->problem = &problem;
+
+    // Lazy initialization
+    GUARD_CU(BaseEnactor::Init(problem, Enactor_None, 2, NULL, target, false));
+    for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+      GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+      auto &enactor_slice = this->enactor_slices[gpu * this->num_gpus + 0];
+      auto &graph = problem.sub_graphs[gpu];
+      GUARD_CU(enactor_slice.frontier.Allocate(graph.nodes, graph.edges,
+                                               this->queue_factors));
     }
 
-    /**
-     * @brief geo destructor
-     */
-    virtual ~Enactor() { /*Release();*/ }
-
-    /*
-     * @brief Releasing allocated memory space
-     * @param target The location to release memory from
-     * \return cudaError_t error message(s), if any
-     */
-    cudaError_t Release(util::Location target = util::LOCATION_ALL)
-    {
-        cudaError_t retval = cudaSuccess;
-        GUARD_CU(BaseEnactor::Release(target));
-        delete []iterations; iterations = NULL;
-        problem = NULL;
-        return retval;
+    iterations = new IterationT[this->num_gpus];
+    for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+      GUARD_CU(iterations[gpu].Init(this, gpu));
     }
 
-    /**
-     * @brief Initialize the problem.
-     * @param[in] problem The problem object.
-     * @param[in] target Target location of data
-     * \return cudaError_t error message(s), if any
-     */
-    cudaError_t Init(
-        Problem          &problem,
-        util::Location    target = util::DEVICE)
-    {
-        cudaError_t retval = cudaSuccess;
-        this->problem = &problem;
+    GUARD_CU(this->Init_Threads(
+        this, (CUT_THREADROUTINE) & (GunrockThread<EnactorT>)));
+    return retval;
+  }
 
-        // Lazy initialization
-        GUARD_CU(BaseEnactor::Init(
-            problem, Enactor_None,
-            // <TODO> change to how many frontier queues, and their types
-            2, NULL,
-            // </TODO>
-            target, false));
-        for (int gpu = 0; gpu < this -> num_gpus; gpu ++) {
-            GUARD_CU(util::SetDevice(this -> gpu_idx[gpu]));
-            auto &enactor_slice = this -> enactor_slices[gpu * this -> num_gpus + 0];
-            auto &graph = problem.sub_graphs[gpu];
-            GUARD_CU(enactor_slice.frontier.Allocate(
-                graph.nodes, graph.edges, this -> queue_factors));
+  /**
+   * @brief one run of geo, to be called within GunrockThread
+   * @param thread_data Data for the CPU thread
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Run(ThreadSlice &thread_data) {
+    gunrock::app::Iteration_Loop<0, 1, IterationT>(
+        thread_data, iterations[thread_data.thread_num]);
+    return cudaSuccess;
+  }
+
+  /**
+   * @brief Reset enactor
+   * @param[in] target Target location of data
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Reset(util::Location target = util::DEVICE) {
+    typedef typename GraphT::GpT GpT;
+    cudaError_t retval = cudaSuccess;
+
+    GUARD_CU(BaseEnactor::Reset(target));
+
+    SizeT nodes = this->problem->data_slices[0][0].sub_graph[0].nodes;
+    printf("nodes=%d\n", nodes);
+
+    for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+      if (this->num_gpus == 1) {
+        this->thread_slices[gpu].init_size = nodes;
+        for (int peer_ = 0; peer_ < this->num_gpus; peer_++) {
+          auto &frontier =
+              this->enactor_slices[gpu * this->num_gpus + peer_].frontier;
+          frontier.queue_length = (peer_ == 0) ? nodes : 0;
+          if (peer_ == 0) {
+            util::Array1D<SizeT, VertexT> tmp;
+            tmp.Allocate(nodes, target | util::HOST);
+            for (SizeT i = 0; i < nodes; ++i) {
+              tmp[i] = (VertexT)i % nodes;
+            }
+            GUARD_CU(tmp.Move(util::HOST, target));
+
+            GUARD_CU(frontier.V_Q()->ForEach(
+                tmp,
+                [] __host__ __device__(VertexT & v, VertexT & i) { v = i; },
+                nodes, target, 0));
+
+            tmp.Release();
+          }
         }
-
-        iterations = new IterationT[this -> num_gpus];
-        for (int gpu = 0; gpu < this -> num_gpus; gpu ++) {
-            GUARD_CU(iterations[gpu].Init(this, gpu));
-        }
-
-        GUARD_CU(this -> Init_Threads(this,
-            (CUT_THREADROUTINE)&(GunrockThread<EnactorT>)));
-        return retval;
+      } else {
+        // MULTIGPU INCOMPLETE
+      }
     }
 
-    /**
-      * @brief one run of geo, to be called within GunrockThread
-      * @param thread_data Data for the CPU thread
-      * \return cudaError_t error message(s), if any
-      */
-    cudaError_t Run(ThreadSlice &thread_data)
-    {
-        gunrock::app::Iteration_Loop<
-            // <TODO> change to how many {VertexT, ValueT} data need to communicate
-            //       per element in the inter-GPU sub-frontiers
-            0, 1,
-            // </TODO>
-            IterationT>(
-            thread_data, iterations[thread_data.thread_num]);
-        return cudaSuccess;
-    }
+    GUARD_CU(BaseEnactor::Sync());
+    return retval;
+  }
 
-    /**
-     * @brief Reset enactor
-     * @param[in] target Target location of data
-     * \return cudaError_t error message(s), if any
-     */
-    cudaError_t Reset(
-        // <TODO> problem specific data if necessary, eg
-        // </TODO>
-        util::Location target = util::DEVICE)
-    {
-        typedef typename GraphT::GpT GpT;
-        cudaError_t retval = cudaSuccess;
-       
-        GUARD_CU(BaseEnactor::Reset(target));
-
-        SizeT nodes = this -> problem -> data_slices[0][0].sub_graph[0].nodes;
-        printf("nodes=%d\n", nodes);
-
-        for (int gpu = 0; gpu < this->num_gpus; gpu++) {
-           if (this->num_gpus == 1) {
-               this -> thread_slices[gpu].init_size = nodes;
-               for (int peer_ = 0; peer_ < this -> num_gpus; peer_++) {
-                   auto &frontier = this -> enactor_slices[gpu * this -> num_gpus + peer_].frontier;
-                   frontier.queue_length = (peer_ == 0) ? nodes : 0;
-                   if (peer_ == 0) {
-
-                      util::Array1D<SizeT, VertexT> tmp;
-                      tmp.Allocate(nodes, target | util::HOST);
-                      for(SizeT i = 0; i < nodes; ++i) {
-                          tmp[i] = (VertexT)i % nodes;
-                      }
-                      GUARD_CU(tmp.Move(util::HOST, target));
-
-                      GUARD_CU(frontier.V_Q() -> ForEach(tmp,
-                          []__host__ __device__ (VertexT &v, VertexT &i) {
-                          v = i;
-                      }, nodes, target, 0));
-
-                      tmp.Release();
-                 }
-               }
-           } else {
-                // MULTIGPU INCOMPLETE
-           }
-	}
- 
-        GUARD_CU(BaseEnactor::Sync());
-        return retval;
-    }
-
-    /**
-     * @brief Enacts a geo computing on the specified graph.
+  /**
+   * @brief Enacts a geo computing on the specified graph.
 ...
-     * \return cudaError_t error message(s), if any
-     */
-    cudaError_t Enact(
-        // <TODO> problem specific data if necessary, eg
-        // </TODO>
-    )
-    {
-        cudaError_t retval = cudaSuccess;
-        GUARD_CU(this -> Run_Threads(this));
-        util::PrintMsg("GPU Template Done.", this -> flag & Debug);
-        return retval;
-    }
+   * \return cudaError_t error message(s), if any
+   */
+  cudaError_t Enact() {
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(this->Run_Threads(this));
+    util::PrintMsg("GPU Template Done.", this->flag & Debug);
+    return retval;
+  }
 };
 
-} // namespace geo
-} // namespace app
-} // namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // Leave this at the end of the file
 // Local Variables:

--- a/gunrock/app/geo/geo_problem.cuh
+++ b/gunrock/app/geo/geo_problem.cuh
@@ -20,20 +20,17 @@ namespace gunrock {
 namespace app {
 namespace geo {
 
-
 /**
  * @brief Speciflying parameters for Geo Problem
- * @param  parameters  The util::Parameter<...> structure holding all parameter info
- * \return cudaError_t error message(s), if any
+ * @param  parameters  The util::Parameter<...> structure holding all parameter
+ * info \return cudaError_t error message(s), if any
  */
-cudaError_t UseParameters_problem(
-    util::Parameters &parameters)
-{
-    cudaError_t retval = cudaSuccess;
+cudaError_t UseParameters_problem(util::Parameters &parameters) {
+  cudaError_t retval = cudaSuccess;
 
-    GUARD_CU(gunrock::app::UseParameters_problem(parameters));
+  GUARD_CU(gunrock::app::UseParameters_problem(parameters));
 
-    return retval;
+  return retval;
 }
 
 /**
@@ -41,367 +38,330 @@ cudaError_t UseParameters_problem(
  * @tparam _GraphT  Type of the graph
  * @tparam _FLAG    Problem flags
  */
-template <
-    typename _GraphT,
-    ProblemFlag _FLAG = Problem_None>
-struct Problem : ProblemBase<_GraphT, _FLAG>
-{
-    typedef _GraphT GraphT;
-    static const ProblemFlag FLAG = _FLAG;
-    typedef typename GraphT::VertexT VertexT;
-    typedef typename GraphT::ValueT  ValueT;
-    typedef typename GraphT::SizeT   SizeT;
-    typedef typename GraphT::CsrT    CsrT;
-    typedef typename GraphT::GpT     GpT;
+template <typename _GraphT, ProblemFlag _FLAG = Problem_None>
+struct Problem : ProblemBase<_GraphT, _FLAG> {
+  typedef _GraphT GraphT;
+  static const ProblemFlag FLAG = _FLAG;
+  typedef typename GraphT::VertexT VertexT;
+  typedef typename GraphT::ValueT ValueT;
+  typedef typename GraphT::SizeT SizeT;
+  typedef typename GraphT::CsrT CsrT;
+  typedef typename GraphT::GpT GpT;
 
-    typedef ProblemBase   <GraphT, FLAG> BaseProblem;
-    typedef DataSliceBase <GraphT, FLAG> BaseDataSlice;
+  typedef ProblemBase<GraphT, FLAG> BaseProblem;
+  typedef DataSliceBase<GraphT, FLAG> BaseDataSlice;
 
-    // ----------------------------------------------------------------
-    // Dataslice structure
+  // ----------------------------------------------------------------
+  // Dataslice structure
 
-    /**
-     * @brief Data structure containing problem specific data on indivual GPU.
-     */
-    struct DataSlice : BaseDataSlice
-    {
-        util::Array1D<SizeT, ValueT>  latitude;
-	util::Array1D<SizeT, ValueT>  longitude;
+  /**
+   * @brief Data structure containing problem specific data on indivual GPU.
+   */
+  struct DataSlice : BaseDataSlice {
+    util::Array1D<SizeT, ValueT> latitude;
+    util::Array1D<SizeT, ValueT> longitude;
 
-	util::Array1D<SizeT, SizeT>   valid_locations;
+    util::Array1D<SizeT, SizeT> valid_locations;
 
-	util::Array1D<SizeT, SizeT>   active;
+    util::Array1D<SizeT, SizeT> active;
 
-	// util::Array1D<SizeT, ValueT>  D;
-        util::Array1D<SizeT, ValueT>  Dinv;
+    util::Array1D<SizeT, ValueT> Dinv;
 
-	bool			      geo_complete;
-
-  	SizeT			      active_; 
-	int			      geo_iter;
-	
-
-        /*
-         * @brief Default constructor
-         */
-        DataSlice() : BaseDataSlice()
-        {
-            latitude		.SetName("latitude");
-	    longitude		.SetName("longitude");
-	    active		.SetName("active");
-	    // D			.SetName("D");
-	    Dinv		.SetName("Dinv");
-        }
-
-        /*
-         * @brief Default destructor
-         */
-        virtual ~DataSlice() { Release(); }
-
-        /*
-         * @brief Releasing allocated memory space
-         * @param[in] target      The location to release memory from
-         * \return    cudaError_t Error message(s), if any
-         */
-        cudaError_t Release(util::Location target = util::LOCATION_ALL)
-        {
-            cudaError_t retval = cudaSuccess;
-            if (target & util::DEVICE)
-                GUARD_CU(util::SetDevice(this->gpu_idx));
-
-            GUARD_CU(latitude		.Release(target));
-            GUARD_CU(longitude          .Release(target));
-
-	    GUARD_CU(valid_locations	.Release(target));
-
-	    GUARD_CU(active		.Release(target));
-
-	    // GUARD_CU(D		.Release(target));
-	    GUARD_CU(Dinv		.Release(target));
-
-            GUARD_CU(BaseDataSlice ::Release(target));
-            return retval;
-        }
-
-        /**
-         * @brief initializing sssp-specific data on each gpu
-         * @param     sub_graph   Sub graph on the GPU.
-         * @param[in] gpu_idx     GPU device index
-         * @param[in] target      Targeting device location
-         * @param[in] flag        Problem flag containling options
-         * \return    cudaError_t Error message(s), if any
-         */
-        cudaError_t Init(
-            GraphT        &sub_graph,
-            int            num_gpus,
-            int            gpu_idx,
-            ProblemFlag    flag,
-	    bool	   geo_complete_,
-	    util::Location target = util::DEVICE)
-        {
-            cudaError_t retval  = cudaSuccess;
-
-            GUARD_CU(BaseDataSlice::Init(sub_graph, num_gpus, gpu_idx, target, flag));
-	    SizeT nodes = this -> sub_graph -> nodes;
-	    SizeT edges = this -> sub_graph -> edges + 1;
-
-	    printf("Number of nodes for allocation: %u\n", nodes);
-
-	    geo_complete = geo_complete_;
-
-            GUARD_CU(latitude		.Allocate(nodes, target));
-            GUARD_CU(longitude          .Allocate(nodes, target));
-
-	    GUARD_CU(valid_locations	.Allocate(nodes, target));
-
-	    GUARD_CU(active		.Allocate(1, util::HOST|target));
-
-	    // GUARD_CU(D		.Allocate(edges, target));
-	    GUARD_CU(Dinv		.Allocate(edges, target));
-
-            if (target & util::DEVICE) {
-                GUARD_CU(sub_graph.CsrT::Move(util::HOST, target, this -> stream));
-            }
-            return retval;
-        }
-
-        /**
-         * @brief Reset problem function. Must be called prior to each run.
-         * @param[in] target      Targeting device location
-         * \return    cudaError_t Error message(s), if any
-         */
-        cudaError_t Reset(
-		ValueT *h_latitude,
-		ValueT *h_longitude,
-		int     _geo_iter,
-		util::Location target = util::DEVICE)
-        {
-            cudaError_t retval = cudaSuccess;
-            SizeT nodes = this -> sub_graph -> nodes;
-	    SizeT edges = this -> sub_graph -> edges + 1;
-
-            // Ensure data are allocated
-            GUARD_CU(latitude		.EnsureSize_(nodes, target));
-	    GUARD_CU(longitude		.EnsureSize_(nodes, target));
-	
-	    GUARD_CU(valid_locations	.EnsureSize_(nodes, target));
-
-	    GUARD_CU(active		.EnsureSize_(1, util::HOST|target));
-
-	    // GUARD_CU(D		.EnsureSize_(edges, target));
-	    GUARD_CU(Dinv               .EnsureSize_(edges, target));
-
-	    this -> geo_iter = _geo_iter;
-
-            // Reset data
-
-	    // Using spatial center we can determine the invalid predicted locations.
-	    GUARD_CU(active.ForAll([]__host__ __device__ (SizeT *x, const VertexT &pos)
-	    {
-		x[pos] = 0;
-            }, 1, target, this -> stream));
-
-	    this -> active_ = 0;
-
-	    // Assumes that all vertices have invalid positions, in reality
-	    // a preprocessing step is needed to assign nodes that do have
-	    // positions to have proper positions already.
-	    GUARD_CU(latitude	.SetPointer(h_latitude, nodes, util::HOST));
-            GUARD_CU(latitude	.Move(util::HOST, util::DEVICE));
-
-            GUARD_CU(longitude  .SetPointer(h_longitude, nodes, util::HOST));
-            GUARD_CU(longitude  .Move(util::HOST, util::DEVICE));
-
-            return retval;
-        }
-    }; // DataSlice
-
-    // Set of data slices (one for each GPU)
-    util::Array1D<SizeT, DataSlice> *data_slices;
     bool geo_complete;
 
-    // ----------------------------------------------------------------
-    // Problem Methods
+    SizeT active_;
+    int geo_iter;
+    int spatial_iter;
 
-    /**
-     * @brief geolocation default constructor
+    /*
+     * @brief Default constructor
      */
-    Problem(
-        util::Parameters &_parameters,
-        ProblemFlag _flag = Problem_None) :
-        BaseProblem(_parameters, _flag),
-        data_slices(NULL) {
-
-	geo_complete = _parameters.Get<bool>("geo-complete");
+    DataSlice() : BaseDataSlice() {
+      latitude.SetName("latitude");
+      longitude.SetName("longitude");
+      active.SetName("active");
+      Dinv.SetName("Dinv");
     }
 
-    /**
-     * @brief geolocation default destructor
+    /*
+     * @brief Default destructor
      */
-    virtual ~Problem() { Release(); }
+    virtual ~DataSlice() { Release(); }
 
     /*
      * @brief Releasing allocated memory space
      * @param[in] target      The location to release memory from
      * \return    cudaError_t Error message(s), if any
      */
-    cudaError_t Release(util::Location target = util::LOCATION_ALL)
-    {
-        cudaError_t retval = cudaSuccess;
-        if (data_slices == NULL) return retval;
-        for (int i = 0; i < this->num_gpus; i++)
-            GUARD_CU(data_slices[i].Release(target));
+    cudaError_t Release(util::Location target = util::LOCATION_ALL) {
+      cudaError_t retval = cudaSuccess;
+      if (target & util::DEVICE) GUARD_CU(util::SetDevice(this->gpu_idx));
 
-        if ((target & util::HOST) != 0 &&
-            data_slices[0].GetPointer(util::DEVICE) == NULL)
-        {
-            delete[] data_slices; data_slices=NULL;
-        }
-        GUARD_CU(BaseProblem::Release(target));
-        return retval;
-    }
-    
-    /**
-     * @brief Copy result distancess computed on GPUs back to host-side arrays.
-...
-     * \return     cudaError_t Error message(s), if any
-     */
-    cudaError_t Extract(
-        ValueT *h_predicted_lat,
-	ValueT *h_predicted_lon,
-        util::Location target = util::DEVICE)
-    {
-        cudaError_t retval = cudaSuccess;
-        SizeT nodes = this -> org_graph -> nodes;
+      GUARD_CU(latitude.Release(target));
+      GUARD_CU(longitude.Release(target));
 
-        if (this-> num_gpus == 1) {
-            auto &data_slice = data_slices[0][0];
+      GUARD_CU(valid_locations.Release(target));
 
-            // Set device
-            if (target == util::DEVICE) {
+      GUARD_CU(active.Release(target));
 
-                GUARD_CU(util::SetDevice(this->gpu_idx[0]));
+      // GUARD_CU(D		.Release(target));
+      GUARD_CU(Dinv.Release(target));
 
-                GUARD_CU(data_slice.latitude.SetPointer(h_predicted_lat, nodes, util::HOST));
-                GUARD_CU(data_slice.latitude.Move(util::DEVICE, util::HOST));
-
-                GUARD_CU(data_slice.longitude.SetPointer(h_predicted_lon, nodes, util::HOST));
-                GUARD_CU(data_slice.longitude.Move(util::DEVICE, util::HOST));
-
-            } else if (target == util::HOST) {
-
-                GUARD_CU(data_slice.latitude.ForEach(h_predicted_lat,
-                   []__host__ __device__ (const ValueT &device_val, ValueT &host_val){
-                       host_val = device_val;
-                   }, nodes, util::HOST));
-
-                GUARD_CU(data_slice.longitude.ForEach(h_predicted_lon,
-                   []__host__ __device__ (const ValueT &device_val, ValueT &host_val){
-                       host_val = device_val;
-                   }, nodes, util::HOST));
-            }
-        } else { // num_gpus != 1
-            
-            // ============ INCOMPLETE TEMPLATE - MULTIGPU ============
-            
-            // // TODO: extract the results from multiple GPUs, e.g.:
-            // // util::Array1D<SizeT, ValueT *> th_distances;
-            // // th_distances.SetName("bfs::Problem::Extract::th_distances");
-            // // GUARD_CU(th_distances.Allocate(this->num_gpus, util::HOST));
-
-            // for (int gpu = 0; gpu < this->num_gpus; gpu++)
-            // {
-            //     auto &data_slice = data_slices[gpu][0];
-            //     if (target == util::DEVICE)
-            //     {
-            //         GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
-            //         // GUARD_CU(data_slice.distances.Move(util::DEVICE, util::HOST));
-            //     }
-            //     // th_distances[gpu] = data_slice.distances.GetPointer(util::HOST);
-            // } //end for(gpu)
-
-            // for (VertexT v = 0; v < nodes; v++)
-            // {
-            //     int gpu = this -> org_graph -> GpT::partition_table[v];
-            //     VertexT v_ = v;
-            //     if ((GraphT::FLAG & gunrock::partitioner::Keep_Node_Num) != 0)
-            //         v_ = this -> org_graph -> GpT::convertion_table[v];
-
-            //     // h_distances[v] = th_distances[gpu][v_];
-            // }
-
-            // // GUARD_CU(th_distances.Release());
-        }
-
-        return retval;
+      GUARD_CU(BaseDataSlice ::Release(target));
+      return retval;
     }
 
     /**
-     * @brief initialization function.
-     * @param     graph       The graph that SSSP processes on
-     * @param[in] Location    Memory location to work on
+     * @brief initializing sssp-specific data on each gpu
+     * @param     sub_graph   Sub graph on the GPU.
+     * @param[in] gpu_idx     GPU device index
+     * @param[in] target      Targeting device location
+     * @param[in] flag        Problem flag containling options
      * \return    cudaError_t Error message(s), if any
      */
-    cudaError_t Init(
-            GraphT           &graph,
-            util::Location    target = util::DEVICE)
-    {
-        cudaError_t retval = cudaSuccess;
-        GUARD_CU(BaseProblem::Init(graph, target));
-        data_slices = new util::Array1D<SizeT, DataSlice>[this->num_gpus];
+    cudaError_t Init(GraphT &sub_graph, int num_gpus, int gpu_idx,
+                     ProblemFlag flag, bool geo_complete_,
+                     util::Location target = util::DEVICE) {
+      cudaError_t retval = cudaSuccess;
 
-        for (int gpu = 0; gpu < this->num_gpus; gpu++) {
-            data_slices[gpu].SetName("data_slices[" + std::to_string(gpu) + "]");
-            if (target & util::DEVICE)
-                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+      GUARD_CU(BaseDataSlice::Init(sub_graph, num_gpus, gpu_idx, target, flag));
+      SizeT nodes = this->sub_graph->nodes;
+      SizeT edges = this->sub_graph->edges + 1;
 
-            GUARD_CU(data_slices[gpu].Allocate(1, target | util::HOST));
+      printf("Number of nodes for allocation: %u\n", nodes);
 
-            auto &data_slice = data_slices[gpu][0];
-            GUARD_CU(data_slice.Init(
-                this -> sub_graphs[gpu],
-                this -> num_gpus,
-                this -> gpu_idx[gpu],
-                this -> flag,
-		this -> geo_complete,
-		target
-            ));
-        }
+      geo_complete = geo_complete_;
 
-        return retval;
+      GUARD_CU(latitude.Allocate(nodes, target));
+      GUARD_CU(longitude.Allocate(nodes, target));
+
+      GUARD_CU(valid_locations.Allocate(nodes, target));
+
+      GUARD_CU(active.Allocate(1, util::HOST | target));
+
+      GUARD_CU(Dinv.Allocate(edges, target));
+
+      if (target & util::DEVICE) {
+        GUARD_CU(sub_graph.CsrT::Move(util::HOST, target, this->stream));
+      }
+      return retval;
     }
 
     /**
      * @brief Reset problem function. Must be called prior to each run.
-     * @param[in] src      Source vertex to start.
-     * @param[in] location Memory location to work on
-     * \return cudaError_t Error message(s), if any
+     * @param[in] target      Targeting device location
+     * \return    cudaError_t Error message(s), if any
      */
-    cudaError_t Reset(
-        ValueT *h_latitude,
-	ValueT *h_longitude,
-	int     _geo_iter,
-        util::Location target = util::DEVICE)
-    {
-        cudaError_t retval = cudaSuccess;
+    cudaError_t Reset(ValueT *h_latitude, ValueT *h_longitude, int _geo_iter,
+                      int _spatial_iter, util::Location target = util::DEVICE) {
+      cudaError_t retval = cudaSuccess;
+      SizeT nodes = this->sub_graph->nodes;
+      SizeT edges = this->sub_graph->edges + 1;
 
-        // Reset data slices
-        for (int gpu = 0; gpu < this->num_gpus; ++gpu) {
-            if (target & util::DEVICE)
-                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
-            GUARD_CU(data_slices[gpu] -> Reset(h_latitude, h_longitude, _geo_iter, target));
-            GUARD_CU(data_slices[gpu].Move(util::HOST, target));
-        }
+      // Ensure data are allocated
+      GUARD_CU(latitude.EnsureSize_(nodes, target));
+      GUARD_CU(longitude.EnsureSize_(nodes, target));
 
+      GUARD_CU(valid_locations.EnsureSize_(nodes, target));
 
-        GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
-        return retval;
+      GUARD_CU(active.EnsureSize_(1, util::HOST | target));
+
+      GUARD_CU(Dinv.EnsureSize_(edges, target));
+
+      this->geo_iter = _geo_iter;
+      this->spatial_iter = _spatial_iter;
+
+      // Reset data
+
+      // Using spatial center we can determine the invalid predicted locations.
+      GUARD_CU(active.ForAll(
+          [] __host__ __device__(SizeT * x, const VertexT &pos) { x[pos] = 0; },
+          1, target, this->stream));
+
+      this->active_ = 0;
+
+      // Assumes that all vertices have invalid positions, in reality
+      // a preprocessing step is needed to assign nodes that do have
+      // positions to have proper positions already.
+      GUARD_CU(latitude.SetPointer(h_latitude, nodes, util::HOST));
+      GUARD_CU(latitude.Move(util::HOST, util::DEVICE));
+
+      GUARD_CU(longitude.SetPointer(h_longitude, nodes, util::HOST));
+      GUARD_CU(longitude.Move(util::HOST, util::DEVICE));
+
+      return retval;
     }
+  };  // DataSlice
+
+  // Set of data slices (one for each GPU)
+  util::Array1D<SizeT, DataSlice> *data_slices;
+  bool geo_complete;
+
+  // ----------------------------------------------------------------
+  // Problem Methods
+
+  /**
+   * @brief geolocation default constructor
+   */
+  Problem(util::Parameters &_parameters, ProblemFlag _flag = Problem_None)
+      : BaseProblem(_parameters, _flag), data_slices(NULL) {
+    geo_complete = _parameters.Get<bool>("geo-complete");
+  }
+
+  /**
+   * @brief geolocation default destructor
+   */
+  virtual ~Problem() { Release(); }
+
+  /*
+   * @brief Releasing allocated memory space
+   * @param[in] target      The location to release memory from
+   * \return    cudaError_t Error message(s), if any
+   */
+  cudaError_t Release(util::Location target = util::LOCATION_ALL) {
+    cudaError_t retval = cudaSuccess;
+    if (data_slices == NULL) return retval;
+    for (int i = 0; i < this->num_gpus; i++)
+      GUARD_CU(data_slices[i].Release(target));
+
+    if ((target & util::HOST) != 0 &&
+        data_slices[0].GetPointer(util::DEVICE) == NULL) {
+      delete[] data_slices;
+      data_slices = NULL;
+    }
+    GUARD_CU(BaseProblem::Release(target));
+    return retval;
+  }
+
+  /**
+   * @brief Copy result distancess computed on GPUs back to host-side arrays.
+...
+   * \return     cudaError_t Error message(s), if any
+   */
+  cudaError_t Extract(ValueT *h_predicted_lat, ValueT *h_predicted_lon,
+                      util::Location target = util::DEVICE) {
+    cudaError_t retval = cudaSuccess;
+    SizeT nodes = this->org_graph->nodes;
+
+    if (this->num_gpus == 1) {
+      auto &data_slice = data_slices[0][0];
+
+      // Set device
+      if (target == util::DEVICE) {
+        GUARD_CU(util::SetDevice(this->gpu_idx[0]));
+
+        GUARD_CU(
+            data_slice.latitude.SetPointer(h_predicted_lat, nodes, util::HOST));
+        GUARD_CU(data_slice.latitude.Move(util::DEVICE, util::HOST));
+
+        GUARD_CU(data_slice.longitude.SetPointer(h_predicted_lon, nodes,
+                                                 util::HOST));
+        GUARD_CU(data_slice.longitude.Move(util::DEVICE, util::HOST));
+
+      } else if (target == util::HOST) {
+        GUARD_CU(data_slice.latitude.ForEach(
+            h_predicted_lat,
+            [] __host__ __device__(const ValueT &device_val, ValueT &host_val) {
+              host_val = device_val;
+            },
+            nodes, util::HOST));
+
+        GUARD_CU(data_slice.longitude.ForEach(
+            h_predicted_lon,
+            [] __host__ __device__(const ValueT &device_val, ValueT &host_val) {
+              host_val = device_val;
+            },
+            nodes, util::HOST));
+      }
+    } else {  // num_gpus != 1
+
+      // ============ INCOMPLETE TEMPLATE - MULTIGPU ============
+
+      // // TODO: extract the results from multiple GPUs, e.g.:
+      // // util::Array1D<SizeT, ValueT *> th_distances;
+      // // th_distances.SetName("bfs::Problem::Extract::th_distances");
+      // // GUARD_CU(th_distances.Allocate(this->num_gpus, util::HOST));
+
+      // for (int gpu = 0; gpu < this->num_gpus; gpu++)
+      // {
+      //     auto &data_slice = data_slices[gpu][0];
+      //     if (target == util::DEVICE)
+      //     {
+      //         GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+      //         // GUARD_CU(data_slice.distances.Move(util::DEVICE,
+      //         util::HOST));
+      //     }
+      //     // th_distances[gpu] = data_slice.distances.GetPointer(util::HOST);
+      // } //end for(gpu)
+
+      // for (VertexT v = 0; v < nodes; v++)
+      // {
+      //     int gpu = this -> org_graph -> GpT::partition_table[v];
+      //     VertexT v_ = v;
+      //     if ((GraphT::FLAG & gunrock::partitioner::Keep_Node_Num) != 0)
+      //         v_ = this -> org_graph -> GpT::convertion_table[v];
+
+      //     // h_distances[v] = th_distances[gpu][v_];
+      // }
+
+      // // GUARD_CU(th_distances.Release());
+    }
+
+    return retval;
+  }
+
+  /**
+   * @brief initialization function.
+   * @param     graph       The graph that SSSP processes on
+   * @param[in] Location    Memory location to work on
+   * \return    cudaError_t Error message(s), if any
+   */
+  cudaError_t Init(GraphT &graph, util::Location target = util::DEVICE) {
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(BaseProblem::Init(graph, target));
+    data_slices = new util::Array1D<SizeT, DataSlice>[this->num_gpus];
+
+    for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+      data_slices[gpu].SetName("data_slices[" + std::to_string(gpu) + "]");
+      if (target & util::DEVICE) GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+
+      GUARD_CU(data_slices[gpu].Allocate(1, target | util::HOST));
+
+      auto &data_slice = data_slices[gpu][0];
+      GUARD_CU(data_slice.Init(this->sub_graphs[gpu], this->num_gpus,
+                               this->gpu_idx[gpu], this->flag,
+                               this->geo_complete, target));
+    }
+
+    return retval;
+  }
+
+  /**
+   * @brief Reset problem function. Must be called prior to each run.
+   * @param[in] src      Source vertex to start.
+   * @param[in] location Memory location to work on
+   * \return cudaError_t Error message(s), if any
+   */
+  cudaError_t Reset(ValueT *h_latitude, ValueT *h_longitude, int _geo_iter,
+                    int _spatial_iter, util::Location target = util::DEVICE) {
+    cudaError_t retval = cudaSuccess;
+
+    // Reset data slices
+    for (int gpu = 0; gpu < this->num_gpus; ++gpu) {
+      if (target & util::DEVICE) GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+      GUARD_CU(data_slices[gpu]->Reset(h_latitude, h_longitude, _geo_iter,
+                                       _spatial_iter, target));
+      GUARD_CU(data_slices[gpu].Move(util::HOST, target));
+    }
+
+    GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
+    return retval;
+  }
 };
 
-} //namespace geo
-} //namespace app
-} //namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // Leave this at the end of the file
 // Local Variables:

--- a/gunrock/app/geo/geo_spatial.cuh
+++ b/gunrock/app/geo/geo_spatial.cuh
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
 namespace gunrock {
 namespace app {
@@ -29,81 +29,67 @@ namespace geo {
  *        and longitudes in a given set.
  */
 template <typename GraphT, typename ValueT, typename SizeT>
-__host__ void mean(
-    GraphT &graph,
-    ValueT *latitude,
-    ValueT *longitude,
-    SizeT   length,
-    ValueT *y,
-    SizeT   v)
-{
-    typedef typename GraphT::CsrT CsrT;
-    typedef typename GraphT::VertexT VertexT;
+__host__ void mean(GraphT &graph, ValueT *latitude, ValueT *longitude,
+                   SizeT length, ValueT *y, SizeT v) {
+  typedef typename GraphT::CsrT CsrT;
+  typedef typename GraphT::VertexT VertexT;
 
-    // Calculate mean;
-    ValueT a = 0;
-    ValueT b = 0;
+  // Calculate mean;
+  ValueT a = 0;
+  ValueT b = 0;
 
-    SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
-    SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+  SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
+  SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
 
-    SizeT len = 0;
-    for(SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-    {
-        VertexT dest = graph.CsrT::GetEdgeDest(e);
-        if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-        {
-            a += latitude[dest];
-            b += longitude[dest];
-            len++;
-        }
+  SizeT len = 0;
+  for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+    VertexT dest = graph.CsrT::GetEdgeDest(e);
+    if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+      a += latitude[dest];
+      b += longitude[dest];
+      len++;
     }
+  }
 
-    a /= len;
-    b /= len;
+  a /= len;
+  b /= len;
 
-    y[0] = a; // output latitude
-    y[1] = b; // output longitude
+  y[0] = a;  // output latitude
+  y[1] = b;  // output longitude
 
-    // printf("Locations Mean[%u] = <%f, %f> with length = %u\n", v, y[0], y[1], length);
+  // printf("Locations Mean[%u] = <%f, %f> with length = %u\n", v, y[0], y[1],
+  // length);
 
-    return;
+  return;
 }
 
 /**
  * @brief Compute the midpoint of two points on a sphere.
  */
 template <typename ValueT, typename SizeT>
-__host__ void midpoint(
-    ValueT p1_lat,
-    ValueT p1_lon,
-    ValueT p2_lat,
-    ValueT p2_lon,
-    ValueT * latitude,
-    ValueT * longitude,
-    SizeT v)
-{
-    // Convert to radians
-    p1_lat = radians(p1_lat);
-    p1_lon = radians(p1_lon);
-    p2_lat = radians(p2_lat);
-    p2_lon = radians(p2_lon);
+__host__ void midpoint(ValueT p1_lat, ValueT p1_lon, ValueT p2_lat,
+                       ValueT p2_lon, ValueT *latitude, ValueT *longitude,
+                       SizeT v) {
+  // Convert to radians
+  p1_lat = radians(p1_lat);
+  p1_lon = radians(p1_lon);
+  p2_lat = radians(p2_lat);
+  p2_lon = radians(p2_lon);
 
-    ValueT bx, by;
-    bx = cos(p2_lat) * cos(p2_lon - p1_lon);
-    by = cos(p2_lat) * sin(p2_lon - p1_lon);
+  ValueT bx, by;
+  bx = cos(p2_lat) * cos(p2_lon - p1_lon);
+  by = cos(p2_lat) * sin(p2_lon - p1_lon);
 
-    ValueT lat, lon;
-    lat = atan2(sin(p1_lat) + sin(p2_lat), \
-                sqrt((cos(p1_lat) + bx) * (cos(p1_lat) \
-                + bx) + by*by));
+  ValueT lat, lon;
+  lat = atan2(sin(p1_lat) + sin(p2_lat),
+              sqrt((cos(p1_lat) + bx) * (cos(p1_lat) + bx) + by * by));
 
-    lon = p1_lon + atan2(by, cos(p1_lat) + bx);
+  lon = p1_lon + atan2(by, cos(p1_lat) + bx);
 
-    latitude[v] = degrees(lat);
-    longitude[v] = degrees(lon);
+  latitude[v] = degrees(lat);
+  longitude[v] = degrees(lon);
 
-    return;
+  return;
 }
 
 /**
@@ -117,145 +103,107 @@ __host__ void midpoint(
  *        the mode of the set.
  */
 template <typename GraphT, typename ValueT, typename SizeT>
-__host__ void h_spatial_median(
-    GraphT  &graph,
-    SizeT   length,
+__host__ void h_spatial_median(GraphT &graph, SizeT length,
 
-    ValueT *latitude,
-    ValueT *longitude,
+                               ValueT *latitude, ValueT *longitude,
 
-    SizeT   v,
+                               SizeT v,
 
-    ValueT *Dinv,
+                               ValueT *Dinv,
 
-    bool    quiet = false,
-    ValueT  eps = 1e-3,
-    SizeT   max_iter = 1000)
-{
+                               bool quiet = false, int max_iter = 1000,
+                               ValueT eps = 1e-3) {
+  typedef typename GraphT::VertexT VertexT;
+  typedef typename GraphT::CsrT CsrT;
 
-    typedef typename GraphT::VertexT VertexT;
-    typedef typename GraphT::CsrT CsrT;
+  ValueT r, rinv;
+  ValueT Dinvs = 0;
 
-    // Reinitialize these to ::problem
-    // ValueT * D = new ValueT[length];
-    // ValueT * Dinv = new ValueT[length];
-    // ValueT * W = new ValueT[length];
+  SizeT iter_ = 0;
+  SizeT nonzeros = 0;
+  SizeT num_zeros = 0;
 
-    // <TODO> this will be a huge issue
-    // if known locations for a node are
-    // a lot! Will overflood the register
-    // file.
-    // ValueT * D = new ValueT[length];
-    // ValueT * Dinv = new ValueT[length];
-    // </TODO>
+  // Can be done cleaner, but storing lat and long.
+  ValueT R[2], tmp[2], out[2], T[2];
+  ValueT y[2], y1[2];
 
-    ValueT r, rinv;
-    ValueT Dinvs = 0;
+  SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+  SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
 
-    SizeT iter_ = 0;
-    SizeT nonzeros = 0;
-    SizeT num_zeros = 0;
+  // Calculate mean of all <latitude, longitude>
+  // for all possible locations of v;
+  mean(graph, latitude, longitude, length, y, v);
 
-    // Can be done cleaner, but storing lat and long.
-    ValueT R[2], tmp[2], out[2], T[2];
-    ValueT y[2], y1[2];
+  // Calculate the spatial median;
+  while (true) {
+    iter_ += 1;
+    Dinvs = 0;
+    T[0] = 0;
+    T[1] = 0;  // T.lat = 0, T.lon = 0;
+    nonzeros = 0;
 
-    SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
-    SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
+    for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+      VertexT dest = graph.CsrT::GetEdgeDest(e);
+      if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+        ValueT Dist = haversine(latitude[dest], longitude[dest], y[0], y[1]);
 
-    // Calculate mean of all <latitude, longitude>
-    // for all possible locations of v;
-    mean (graph, 
-	  latitude, 
-	  longitude,
-          length, 
-	  y, 
-	  v);
-
-    // Calculate the spatial median;
-    while (true)
-    {
-        iter_ += 1;
-        Dinvs = 0;
-        T[0] = 0; T[1] = 0; // T.lat = 0, T.lon = 0;
-        nonzeros = 0;
-
-
-	for(SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-        {
-            VertexT dest = graph.CsrT::GetEdgeDest(e);
-            if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-            {
-
-             ValueT Dist = haversine(latitude[dest],
-                              longitude[dest],
-                              y[0], y[1]);
-
-	
-	     Dinv[e] = Dist == 0 ? 0 : 1/Dist;
-	     nonzeros = Dist != 0 ? nonzeros + 1 : nonzeros;
-	     Dinvs += Dinv[e];
-	    }
-	}
-
-	SizeT len = 0;
-        for(SizeT e = start_edge; e < start_edge + num_neighbors; e++)
-        {
-            VertexT dest = graph.CsrT::GetEdgeDest(e);
-            if(util::isValid(latitude[dest]) && util::isValid(longitude[dest]))
-            {
-	        T[0] += (Dinv[e]/Dinvs) * latitude[dest];
-	        T[1] += (Dinv[e]/Dinvs) * longitude[dest];
-		len++;
-	    }
-	}
-
-	num_zeros = len - nonzeros;
-	if (num_zeros == 0)
-	{
-	    y1[0] = T[0];
-	    y1[1] = T[1];
-	}
-
-	else if (num_zeros == len)
-	{
-	    latitude[v] = y[0];
-	    longitude[v] = y[1];
-	    return;
-	}
-
-	else
-	{
-	    R[0] = (T[0] - y[0]) * Dinvs;
-	    R[1] = (T[1] - y[1]) * Dinvs;
-	    r = sqrt(R[0] * R[0] + R[1] * R[1]);
-	    rinv = r == 0 ? : num_zeros / r;
-
-	    y1[0] = std::max(0.0f, 1-rinv) * T[0]
-	          + std::min(1.0f, rinv)   * y[0]; // latitude
-	    y1[1] = std::max(0.0f, 1-rinv) * T[1]
-	          + std::min(1.0f, rinv)   * y[1]; // longitude
-	}
-
-	tmp[0] = y[0] - y1[0];
-	tmp[1] = y[1] - y1[1];
-
-	if((sqrt(tmp[0] * tmp[0] + tmp[1] * tmp[1])) < eps || (iter_ > max_iter))
-	{
-	    latitude[v] = y1[0];
-	    longitude[v] = y1[1];
-	    return;
-	}
-
-	y[0] = y1[0];
-	y[1] = y1[1];
+        Dinv[e] = Dist == 0 ? 0 : 1 / Dist;
+        nonzeros = Dist != 0 ? nonzeros + 1 : nonzeros;
+        Dinvs += Dinv[e];
+      }
     }
+
+    SizeT len = 0;
+    for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+      VertexT dest = graph.CsrT::GetEdgeDest(e);
+      if (util::isValid(latitude[dest]) && util::isValid(longitude[dest])) {
+        T[0] += (Dinv[e] / Dinvs) * latitude[dest];
+        T[1] += (Dinv[e] / Dinvs) * longitude[dest];
+        len++;
+      }
+    }
+
+    num_zeros = len - nonzeros;
+    if (num_zeros == 0) {
+      y1[0] = T[0];
+      y1[1] = T[1];
+    }
+
+    else if (num_zeros == len) {
+      latitude[v] = y[0];
+      longitude[v] = y[1];
+      return;
+    }
+
+    else {
+      R[0] = (T[0] - y[0]) * Dinvs;
+      R[1] = (T[1] - y[1]) * Dinvs;
+      r = sqrt(R[0] * R[0] + R[1] * R[1]);
+      rinv = r == 0 ?: num_zeros / r;
+
+      y1[0] = std::max(0.0f, 1 - rinv) * T[0] +
+              std::min(1.0f, rinv) * y[0];  // latitude
+      y1[1] = std::max(0.0f, 1 - rinv) * T[1] +
+              std::min(1.0f, rinv) * y[1];  // longitude
+    }
+
+    tmp[0] = y[0] - y1[0];
+    tmp[1] = y[1] - y1[1];
+
+    if ((sqrt(tmp[0] * tmp[0] + tmp[1] * tmp[1])) < eps || (iter_ > max_iter)) {
+      latitude[v] = y1[0];
+      longitude[v] = y1[1];
+      return;
+    }
+
+    y[0] = y1[0];
+    y[1] = y1[1];
+  }
 }
 
-
-} // namespace geo
-} // namespace app
-} // namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // Leave this at the end of the file
 // Local Variables:

--- a/gunrock/app/geo/geo_spatial.cuh
+++ b/gunrock/app/geo/geo_spatial.cuh
@@ -134,6 +134,7 @@ __host__ void h_spatial_median(
 {
 
     typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::CsrT CsrT;
 
     // Reinitialize these to ::problem
     // ValueT * D = new ValueT[length];
@@ -164,8 +165,12 @@ __host__ void h_spatial_median(
 
     // Calculate mean of all <latitude, longitude>
     // for all possible locations of v;
-    mean (graph, latitude, longitude,
-            length, y, v);
+    mean (graph, 
+	  latitude, 
+	  longitude,
+          length, 
+	  y, 
+	  v);
 
     // Calculate the spatial median;
     while (true)
@@ -226,10 +231,10 @@ __host__ void h_spatial_median(
 	    r = sqrt(R[0] * R[0] + R[1] * R[1]);
 	    rinv = r == 0 ? : num_zeros / r;
 
-	    y1[0] = std::max((ValueT) 0.0, (ValueT) 1-rinv) * T[0]
-	          + std::min((ValueT) 1.0, (ValueT) rinv) * y[0]; // latitude
-	    y1[1] = std::max((ValueT) 0.0, (ValueT) 1-rinv) * T[1]
-	          + std::min((ValueT) 1.0, (ValueT) rinv) * y[1]; // longitude
+	    y1[0] = std::max(0.0f, 1-rinv) * T[0]
+	          + std::min(1.0f, rinv)   * y[0]; // latitude
+	    y1[1] = std::max(0.0f, 1-rinv) * T[1]
+	          + std::min(1.0f, rinv)   * y[1]; // longitude
 	}
 
 	tmp[0] = y[0] - y1[0];

--- a/gunrock/app/geo/geo_test.cuh
+++ b/gunrock/app/geo/geo_test.cuh
@@ -20,7 +20,6 @@ namespace gunrock {
 namespace app {
 namespace geo {
 
-
 /******************************************************************************
  * Geolocation Testing Routines
  *****************************************************************************/
@@ -34,146 +33,108 @@ namespace geo {
  * @param[in]   quiet         Whether to print out anything to stdout
  */
 template <typename GraphT>
-double CPU_Reference(
-    const GraphT &graph,
-    typename GraphT::ValueT *latitude,
-    typename GraphT::ValueT *longitude,
-    int geo_iter,
-    bool geo_complete,
-    bool quiet)
-{
-    typedef typename GraphT::SizeT SizeT;
-    typedef typename GraphT::ValueT ValueT;
-    typedef typename GraphT::VertexT VertexT;
-    typedef typename GraphT::CsrT CsrT;
+double CPU_Reference(const GraphT &graph, typename GraphT::ValueT *latitude,
+                     typename GraphT::ValueT *longitude, int geo_iter,
+                     int spatial_iter, bool geo_complete, bool quiet) {
+  typedef typename GraphT::SizeT SizeT;
+  typedef typename GraphT::ValueT ValueT;
+  typedef typename GraphT::VertexT VertexT;
+  typedef typename GraphT::CsrT CsrT;
 
-    SizeT nodes = graph.nodes;
+  SizeT nodes = graph.nodes;
 
-    SizeT edges = graph.edges + 1;
-    ValueT * Dinv = new ValueT[edges];
+  SizeT edges = graph.edges + 1;
+  ValueT *Dinv = new ValueT[edges];
 
-    int iterations = 0;
+  int iterations = 0;
 
-    // Number of nodes with known/predicted locations
-    SizeT active = 0;
-    bool Stop_Condition = false;
+  // Number of nodes with known/predicted locations
+  SizeT active = 0;
+  bool Stop_Condition = false;
 
-    util::CpuTimer cpu_timer;
-    cpu_timer.Start();
-    
-    // implement CPU reference implementation
-    while (!Stop_Condition) 
-    {
-	// Compute operator 
-	// #pragma omp parallel
-	for (SizeT v = 0; v < nodes; ++v) 
-	{
-	    SizeT offset  = graph.GetNeighborListLength(v);
-	    if (!util::isValid(latitude[v]) &&
-                !util::isValid(longitude[v]))
-	    {
+  util::CpuTimer cpu_timer;
+  cpu_timer.Start();
 
-		ValueT neighbor_lat[2], neighbor_lon[2];
+  // implement CPU reference implementation
+  while (!Stop_Condition) {
+    // Compute operator
+    // #pragma omp parallel
+    for (SizeT v = 0; v < nodes; ++v) {
+      SizeT offset = graph.GetNeighborListLength(v);
+      if (!util::isValid(latitude[v]) && !util::isValid(longitude[v])) {
+        ValueT neighbor_lat[2], neighbor_lon[2];
 
-		SizeT start_edge    = graph.CsrT::GetNeighborListOffset(v);
-		SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+        SizeT start_edge = graph.CsrT::GetNeighborListOffset(v);
+        SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
 
-		SizeT i = 0;
+        SizeT i = 0;
 
-		for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) 
-		{
-			VertexT u = graph.CsrT::GetEdgeDest(e);
-			if (util::isValid(latitude[u]) && util::isValid(longitude[u])) 
-			{
-			    neighbor_lat[i%2] = latitude[u];          // last valid latitude
-			    neighbor_lon[i%2] = longitude[u];         // last valid longitude
-			    i++;
-			}
-		}
+        for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
+          VertexT u = graph.CsrT::GetEdgeDest(e);
+          if (util::isValid(latitude[u]) && util::isValid(longitude[u])) {
+            neighbor_lat[i % 2] = latitude[u];   // last valid latitude
+            neighbor_lon[i % 2] = longitude[u];  // last valid longitude
+            i++;
+          }
+        }
 
-		SizeT valid_neighbors = i;
+        SizeT valid_neighbors = i;
 
+        // If no locations found and no neighbors,
+        // point at location (92.0, 182.0)
+        if (valid_neighbors < 1)  // && offset == 0)
+        {
+        }
 
-		// If no locations found and no neighbors,
-		// point at location (92.0, 182.0)
-		if (valid_neighbors < 1) // && offset == 0)
-		{
-			// break;
-		}
+        // If one location found, point at that location
+        if (valid_neighbors == 1) {
+          latitude[v] = neighbor_lat[0];
+          longitude[v] = neighbor_lon[0];
+        }
 
-		// If one location found, point at that location
-		if (valid_neighbors == 1)
-		{
-			latitude[v] = neighbor_lat[0];
-			longitude[v] = neighbor_lon[0];
-			// break;
-		}
+        // If two locations found, compute a midpoint
+        else if (valid_neighbors == 2) {
+          midpoint(neighbor_lat[0], neighbor_lon[0], neighbor_lat[1],
+                   neighbor_lon[1], latitude, longitude, v);
+        }
 
-		// If two locations found, compute a midpoint
-		else if (valid_neighbors == 2)
-		{
-			midpoint(neighbor_lat[0],
-				 neighbor_lon[0],
-				 neighbor_lat[1],
-				 neighbor_lon[1],
-				 latitude,
-				 longitude,
-				 v);
-			// break;
-		}
+        // if locations more than 2, compute spatial
+        // median.
+        else {
+          h_spatial_median(graph, valid_neighbors, latitude, longitude, v, Dinv,
+                           quiet, spatial_iter);
+        }
+      }
+    }
 
-		// if locations more than 2, compute spatial
-		// median.
-		else
-		{
-			h_spatial_median(
-				    graph,
-				    valid_neighbors,
-				    latitude,
-				    longitude,
-				    v,
-				    Dinv,
-				    quiet);
-			// break;
-		}
-	    }
-	}
+    if (geo_complete) {
+      active = 0;
 
-	if(geo_complete) 
-	{	
-	    active = 0;
+      // Check all nodes with known location,
+      // and increment active.
+      for (SizeT v = 0; v < nodes; ++v) {
+        if (util::isValid(latitude[v]) && util::isValid(longitude[v])) {
+          active++;
+        }
+      }
 
-	    // Check all nodes with known location,
-	    // and increment active.
-	    for (SizeT v = 0; v < nodes; ++v) 
-	    {
-	        if (util::isValid(latitude[v]) && 
-	    	    util::isValid(longitude[v])) 
-	        {
-		    active++;
-	        }
-	    }
+      if (active == nodes) Stop_Condition = true;
 
-	    if(active == nodes) 
-	        Stop_Condition = true; 
+      // util::PrintMsg("Current Predicted Locations: "
+      // 		+ std::to_string(active), !quiet);
+    }
 
-	    // util::PrintMsg("Current Predicted Locations: " 
- 	    // 		+ std::to_string(active), !quiet);
-	}
+    else {
+      if (iterations >= geo_iter) Stop_Condition = true;
+    }
 
-	else
-	{
-	    if (iterations >= geo_iter)
-            	Stop_Condition = true;
-	}
+    iterations++;
 
-	iterations++;
+  }  // -> while locations unknown.
 
-    } // -> while locations unknown.
-
-    cpu_timer.Stop();
-    float elapsed = cpu_timer.ElapsedMillis();
-    return elapsed;
+  cpu_timer.Stop();
+  float elapsed = cpu_timer.ElapsedMillis();
+  return elapsed;
 }
 
 /**
@@ -188,47 +149,42 @@ double CPU_Reference(
  */
 template <typename GraphT>
 typename GraphT::SizeT Validate_Results(
-             util::Parameters &parameters,
-             GraphT           &graph,
-             typename GraphT::ValueT *h_predicted_lat,
-             typename GraphT::ValueT *h_predicted_lon,
-             typename GraphT::ValueT *ref_predicted_lat,
-             typename GraphT::ValueT *ref_predicted_lon,
-             bool verbose = true)
-{
-    typedef typename GraphT::VertexT VertexT;
-    typedef typename GraphT::SizeT   SizeT;
+    util::Parameters &parameters, GraphT &graph,
+    typename GraphT::ValueT *h_predicted_lat,
+    typename GraphT::ValueT *h_predicted_lon,
+    typename GraphT::ValueT *ref_predicted_lat,
+    typename GraphT::ValueT *ref_predicted_lon, bool verbose = true) {
+  typedef typename GraphT::VertexT VertexT;
+  typedef typename GraphT::SizeT SizeT;
 
-    SizeT num_errors = 0;
-    bool quiet = parameters.Get<bool>("quiet");
-    bool quick = parameters.Get<bool>("quick");
+  SizeT num_errors = 0;
+  bool quiet = parameters.Get<bool>("quiet");
+  bool quick = parameters.Get<bool>("quick");
 
-    if (!quick) {
-
-    	for(SizeT v = 0; v < graph.nodes; ++v) {
-            printf("Node [ %d ]: Predicted = < %f , %f > Reference = < %f , %f >\n", v, 
-		    h_predicted_lat[v], h_predicted_lon[v], 
-		    ref_predicted_lat[v], ref_predicted_lon[v]);
-	}
-
-    } else {
-
-	for(SizeT v = 0; v < graph.nodes; ++v) {
-            printf("Node [ %d ]: Predicted = < %f , %f >\n", v,
-                    h_predicted_lat[v], h_predicted_lon[v]);
-	}
+  if (!quick) {
+    for (SizeT v = 0; v < graph.nodes; ++v) {
+      printf("Node [ %d ]: Predicted = < %f , %f > Reference = < %f , %f >\n",
+             v, h_predicted_lat[v], h_predicted_lon[v], ref_predicted_lat[v],
+             ref_predicted_lon[v]);
     }
 
-    if(num_errors == 0) {
-       util::PrintMsg(std::to_string(num_errors) + " errors occurred.", !quiet);
+  } else {
+    for (SizeT v = 0; v < graph.nodes; ++v) {
+      printf("Node [ %d ]: Predicted = < %f , %f >\n", v, h_predicted_lat[v],
+             h_predicted_lon[v]);
     }
+  }
 
-    return num_errors;
+  if (num_errors == 0) {
+    util::PrintMsg(std::to_string(num_errors) + " errors occurred.", !quiet);
+  }
+
+  return num_errors;
 }
 
-} // namespace geo
-} // namespace app
-} // namespace gunrock
+}  // namespace geo
+}  // namespace app
+}  // namespace gunrock
 
 // Leave this at the end of the file
 // Local Variables:

--- a/tests/BaseMakefile.mk
+++ b/tests/BaseMakefile.mk
@@ -25,7 +25,7 @@ OSUPPER = $(shell uname -s 2>/dev/null | tr [:lower:] [:upper:])
 #-------------------------------------------------------------------------------
 
 # GEN_SM71 = -gencode=arch=compute_71,code=\"sm_71,compute_71\"
-# GEN_SM70 = -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+GEN_SM70 = -gencode=arch=compute_70,code=\"sm_70,compute_70\"
 # GEN_SM61 = -gencode=arch=compute_61,code=\"sm_61,compute_61\"
 GEN_SM60 = -gencode=arch=compute_60,code=\"sm_60,compute_60\"
 # GEN_SM52 = -gencode=arch=compute_52,code=\"sm_52,compute_52\"
@@ -35,7 +35,7 @@ GEN_SM60 = -gencode=arch=compute_60,code=\"sm_60,compute_60\"
 # GEN_SM30 = -gencode=arch=compute_30,code=\"sm_30,compute_30\"
 
 # SM_TARGETS = #$(GEN_SM30) #$(GEN_SM35) $(GEN_SM30) $(GEN_SM60) $(GEN_SM61)
-SM_TARGETS = $(GEN_SM60)
+SM_TARGETS = $(GEN_SM70)
 #-------------------------------------------------------------------------------
 # Libs
 #-------------------------------------------------------------------------------

--- a/tests/geo/Makefile
+++ b/tests/geo/Makefile
@@ -17,12 +17,12 @@ test: $(EXEC)
 
 $(EXEC) : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
-	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) -g $(ARCH) $(INC) -O3
+	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
 
 a : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
 	rm -f $(EXEC)
-	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) -g $(ARCH) $(INC) -O3 > a.txt 2>&1 || true
+	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3 > a.txt 2>&1 || true
 	grep rror: a.txt; grep arn a.txt
 
 .DEFAULT_GOAL := test

--- a/tests/geo/run.sh
+++ b/tests/geo/run.sh
@@ -1,1 +1,1 @@
-./bin/test_geo_10.0_x86_64 --graph-type=market --graph-file=./geolocation.mtx --labels-file=./locations.labels --geo-iter=2 --geo-complete=false
+./bin/test_geo_10.0_x86_64 --graph-type=market --graph-file=./_data/sample/geolocation.mtx --labels-file=./_data/sample/locations.labels --geo-iter=2 --geo-complete=false

--- a/tests/geo/test_geo.cu
+++ b/tests/geo/test_geo.cu
@@ -20,153 +20,141 @@ using namespace gunrock;
 namespace APP_NAMESPACE = app::geo;
 
 /******************************************************************************
-* Main
-******************************************************************************/
+ * Main
+ ******************************************************************************/
 
 /**
  * @brief Enclosure to the main function
  */
-struct main_struct
-{
-    /**
-     * @brief the actual main function, after type switching
-     * @tparam VertexT    Type of vertex identifier
-     * @tparam SizeT      Type of graph size, i.e. type of edge identifier
-     * @tparam ValueT     Type of edge values
-     * @param  parameters Command line parameters
-     * @param  v,s,val    Place holders for type deduction
-     * \return cudaError_t error message(s), if any
-     */
-    template <
-        typename VertexT, // Use int as the vertex identifier
-        typename SizeT,   // Use int as the graph size type
-        typename ValueT>  // Use int as the value type
-    cudaError_t operator()(util::Parameters &parameters,
-        VertexT v, SizeT s, ValueT val)
-    {
-        // CLI parameters        
-        bool quick = parameters.Get<bool>("quick");
-        bool quiet = parameters.Get<bool>("quiet");
+struct main_struct {
+  /**
+   * @brief the actual main function, after type switching
+   * @tparam VertexT    Type of vertex identifier
+   * @tparam SizeT      Type of graph size, i.e. type of edge identifier
+   * @tparam ValueT     Type of edge values
+   * @param  parameters Command line parameters
+   * @param  v,s,val    Place holders for type deduction
+   * \return cudaError_t error message(s), if any
+   */
+  template <typename VertexT,  // Use int as the vertex identifier
+            typename SizeT,    // Use int as the graph size type
+            typename ValueT>   // Use int as the value type
+  cudaError_t operator()(util::Parameters &parameters, VertexT v, SizeT s,
+                         ValueT val) {
+    // CLI parameters
+    bool quick = parameters.Get<bool>("quick");
+    bool quiet = parameters.Get<bool>("quiet");
 
-        typedef typename app::TestGraph<VertexT, SizeT, ValueT,
-            graph::HAS_EDGE_VALUES | graph::HAS_CSR>
-            GraphT;
+    typedef typename app::TestGraph<VertexT, SizeT, ValueT,
+                                    graph::HAS_EDGE_VALUES | graph::HAS_CSR>
+        GraphT;
 
-        cudaError_t retval = cudaSuccess;
-        util::CpuTimer cpu_timer;
-        GraphT graph;
+    cudaError_t retval = cudaSuccess;
+    util::CpuTimer cpu_timer;
+    GraphT graph;
 
-        cpu_timer.Start();
-        GUARD_CU(graphio::LoadGraph(parameters, graph));
-        cpu_timer.Stop();
-        parameters.Set("load-time", cpu_timer.ElapsedMillis());
-        
-        // <DONE> declare datastructures for reference result
-        ValueT *ref_predicted_lat;
-	ValueT *ref_predicted_lon;
-        // </DONE>
+    cpu_timer.Start();
+    GUARD_CU(graphio::LoadGraph(parameters, graph));
+    cpu_timer.Stop();
+    parameters.Set("load-time", cpu_timer.ElapsedMillis());
 
-	std::string labels_file     = parameters.Get<std::string>("labels-file");
+    // <DONE> declare datastructures for reference result
+    ValueT *ref_predicted_lat;
+    ValueT *ref_predicted_lon;
+    // </DONE>
 
-	util::PrintMsg("Labels File Input: "
-            + labels_file, !quiet);
+    std::string labels_file = parameters.Get<std::string>("labels-file");
 
-	// Input locations from a labels file
-    	ValueT *h_latitude  = new ValueT[graph.nodes];
-    	ValueT *h_longitude = new ValueT[graph.nodes];
+    util::PrintMsg("Labels File Input: " + labels_file, !quiet);
 
-    	retval = gunrock::graphio::labels::Read(parameters, h_latitude, h_longitude);
+    // Input locations from a labels file
+    ValueT *h_latitude = new ValueT[graph.nodes];
+    ValueT *h_longitude = new ValueT[graph.nodes];
 
-    	util::PrintMsg("Debugging Labels -------------", !quiet);
-    	for (int p = 0; p < graph.nodes; p++)
-    	{
-        util::PrintMsg("    locations[ " + std::to_string(p) +
-                            " ] = < " + std::to_string(h_latitude[p]) +
-                            " , " + std::to_string(h_longitude[p]) +
-                            " > ",
-                            !quiet);
-    	}
-   
-        if (!quick) {
-            // <DONE> init datastructures for reference result
-            ref_predicted_lat = new ValueT[graph.nodes];
-            ref_predicted_lon = new ValueT[graph.nodes];
+    retval =
+        gunrock::graphio::labels::Read(parameters, h_latitude, h_longitude);
 
-	    memcpy(ref_predicted_lat, h_latitude, graph.nodes * sizeof(ValueT));
-	    memcpy(ref_predicted_lon, h_longitude, graph.nodes * sizeof(ValueT));
-            // </DONE>
-
-	    bool geo_complete 	= parameters.Get<bool>("geo-complete");
-	    int geo_iter	= parameters.Get<int>("geo-iter");
-
-            // If not in `quick` mode, compute CPU reference implementation
-            util::PrintMsg("__________________________", !quiet);
-            util::PrintMsg("______ CPU Reference _____", !quiet);
-    
-            float elapsed = app::geo::CPU_Reference(
-                graph.csr(),
-                ref_predicted_lat,
-		ref_predicted_lon,
-		geo_iter,
-		geo_complete,
-                quiet);
-            
-            util::PrintMsg("--------------------------\n Elapsed: "
-                + std::to_string(elapsed), !quiet);
-	
-	    util::PrintMsg("__________________________", !quiet);
-        }
-
-        std::vector<std::string> switches{"advance-mode"};
-        
-        GUARD_CU(app::Switch_Parameters(parameters, graph, switches,
-            [
-                // </DONE> pass necessary data to lambda
-		h_latitude,
-		h_longitude,
-                ref_predicted_lat,
-		ref_predicted_lon
-                // </DONE>
-            ](util::Parameters &parameters, GraphT &graph)
-            {
-                // <DONE> pass necessary data to app::Template::RunTests
-                return app::geo::RunTests(parameters, graph,
-					  h_latitude, h_longitude,
-					  ref_predicted_lat, ref_predicted_lon,
-					  util::DEVICE);
-                // </DONE>
-            }));
-
-        if (!quick) {
-            // <DONE> deallocate host references
-            delete[] ref_predicted_lat; ref_predicted_lat = NULL;
-            delete[] ref_predicted_lon; ref_predicted_lon = NULL;
-            // </DONE>
-        }
-        return retval;
+    util::PrintMsg("Debugging Labels -------------", !quiet);
+    for (int p = 0; p < graph.nodes; p++) {
+      util::PrintMsg("    locations[ " + std::to_string(p) + " ] = < " +
+                         std::to_string(h_latitude[p]) + " , " +
+                         std::to_string(h_longitude[p]) + " > ",
+                     !quiet);
     }
+
+    if (!quick) {
+      // <DONE> init datastructures for reference result
+      ref_predicted_lat = new ValueT[graph.nodes];
+      ref_predicted_lon = new ValueT[graph.nodes];
+
+      memcpy(ref_predicted_lat, h_latitude, graph.nodes * sizeof(ValueT));
+      memcpy(ref_predicted_lon, h_longitude, graph.nodes * sizeof(ValueT));
+      // </DONE>
+
+      bool geo_complete = parameters.Get<bool>("geo-complete");
+      int geo_iter = parameters.Get<int>("geo-iter");
+      int spatial_iter = parameters.Get<int>("spatial-iter");
+
+      // If not in `quick` mode, compute CPU reference implementation
+      util::PrintMsg("__________________________", !quiet);
+      util::PrintMsg("______ CPU Reference _____", !quiet);
+
+      float elapsed = app::geo::CPU_Reference(
+          graph.csr(), ref_predicted_lat, ref_predicted_lon, geo_iter,
+          spatial_iter, geo_complete, quiet);
+
+      util::PrintMsg(
+          "--------------------------\n Elapsed: " + std::to_string(elapsed),
+          !quiet);
+
+      util::PrintMsg("__________________________", !quiet);
+    }
+
+    std::vector<std::string> switches{"advance-mode"};
+
+    GUARD_CU(app::Switch_Parameters(
+        parameters, graph, switches,
+        [
+            // </DONE> pass necessary data to lambda
+            h_latitude, h_longitude, ref_predicted_lat, ref_predicted_lon
+            // </DONE>
+    ](util::Parameters &parameters, GraphT &graph) {
+          // <DONE> pass necessary data to app::Template::RunTests
+          return app::geo::RunTests(parameters, graph, h_latitude, h_longitude,
+                                    ref_predicted_lat, ref_predicted_lon,
+                                    util::DEVICE);
+          // </DONE>
+        }));
+
+    if (!quick) {
+      // <DONE> deallocate host references
+      delete[] ref_predicted_lat;
+      ref_predicted_lat = NULL;
+      delete[] ref_predicted_lon;
+      ref_predicted_lon = NULL;
+      // </DONE>
+    }
+    return retval;
+  }
 };
 
-int main(int argc, char** argv)
-{
-    cudaError_t retval = cudaSuccess;
-    util::Parameters parameters("test geolocation");
-    GUARD_CU(graphio::UseParameters(parameters));
-    GUARD_CU(app::geo::UseParameters(parameters));
-    GUARD_CU(app::UseParameters_test(parameters));
-    GUARD_CU(parameters.Parse_CommandLine(argc, argv));
-    if (parameters.Get<bool>("help"))
-    {
-        parameters.Print_Help();
-        return cudaSuccess;
-    }
-    GUARD_CU(parameters.Check_Required());
+int main(int argc, char **argv) {
+  cudaError_t retval = cudaSuccess;
+  util::Parameters parameters("test geolocation");
+  GUARD_CU(graphio::UseParameters(parameters));
+  GUARD_CU(app::geo::UseParameters(parameters));
+  GUARD_CU(app::UseParameters_test(parameters));
+  GUARD_CU(parameters.Parse_CommandLine(argc, argv));
+  if (parameters.Get<bool>("help")) {
+    parameters.Print_Help();
+    return cudaSuccess;
+  }
+  GUARD_CU(parameters.Check_Required());
 
-    return app::Switch_Types<
-        app::VERTEXT_U32B | app::VERTEXT_U64B |
-        app::SIZET_U32B | app::SIZET_U64B |
-        app::VALUET_F32B | app::DIRECTED | app::UNDIRECTED>
-        (parameters, main_struct());
+  return app::Switch_Types<app::VERTEXT_U32B | app::VERTEXT_U64B |
+                           app::SIZET_U32B | app::SIZET_U64B |
+                           app::VALUET_F32B | app::DIRECTED | app::UNDIRECTED>(
+      parameters, main_struct());
 }
 
 // Leave this at the end of the file

--- a/tests/geo/test_geo.cu
+++ b/tests/geo/test_geo.cu
@@ -120,6 +120,8 @@ struct main_struct
             
             util::PrintMsg("--------------------------\n Elapsed: "
                 + std::to_string(elapsed), !quiet);
+	
+	    util::PrintMsg("__________________________", !quiet);
         }
 
         // <TODO> add other switching parameters, if needed

--- a/tests/geo/test_geo.cu
+++ b/tests/geo/test_geo.cu
@@ -60,13 +60,6 @@ struct main_struct
         GUARD_CU(graphio::LoadGraph(parameters, graph));
         cpu_timer.Stop();
         parameters.Set("load-time", cpu_timer.ElapsedMillis());
-
-        // <TODO> get srcs if needed, e.g.:
-        // GUARD_CU(app::Set_Srcs (parameters, graph));
-        // std::vector<VertexT> srcs
-        //    = parameters.Get<std::vector<VertexT> >("srcs");
-        // int num_srcs = srcs.size();
-        // </TODO>
         
         // <DONE> declare datastructures for reference result
         ValueT *ref_predicted_lat;
@@ -124,9 +117,7 @@ struct main_struct
 	    util::PrintMsg("__________________________", !quiet);
         }
 
-        // <TODO> add other switching parameters, if needed
         std::vector<std::string> switches{"advance-mode"};
-        // </TODO>
         
         GUARD_CU(app::Switch_Parameters(parameters, graph, switches,
             [
@@ -171,7 +162,6 @@ int main(int argc, char** argv)
     }
     GUARD_CU(parameters.Check_Required());
 
-    // TODO: change available graph types, according to requirements
     return app::Switch_Types<
         app::VERTEXT_U32B | app::VERTEXT_U64B |
         app::SIZET_U32B | app::SIZET_U64B |


### PR DESCRIPTION
Removed `|E|x2` size `locations` array, and replaces it with 2x random accesses to handle larger graphs.
I plan to add the `|E|x2` implementation back to compare that against fewer random memory access.
Formatted the whole application according to `clang-format -style=Google`.
Added a command line parameter to control how many iterations it needs to do for `spatial-median` calculation, which is separate for the whole app iteration number.