### PR TITLE
Color

### DIFF
--- a/gunrock/app/color/color_app.cu
+++ b/gunrock/app/color/color_app.cu
@@ -37,11 +37,18 @@ cudaError_t UseParameters(util::Parameters &parameters)
     GUARD_CU(UseParameters_enactor(parameters));
 
     // <DONE> add app specific parameters, eg:
-    GUARD_CU(parameters.Use<int>(    
-         "seed",   
-         util::REQUIRED_ARGUMENT | util::OPTIONAL_PARAMETER,  
-         time(NULL),   
-         "seed for random number generator", 
+
+    GUARD_CU(parameters.Use<int>(
+      "usr_iter",
+      util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+      3, "Number of iterations color should run for (default=3).",
+      __FILE__, __LINE__));
+
+    GUARD_CU(parameters.Use<int>(
+         "seed",
+         util::REQUIRED_ARGUMENT | util::OPTIONAL_PARAMETER,
+         time(NULL),
+         "seed for random number generator",
          __FILE__, __LINE__));
 
     GUARD_CU(parameters.Use<bool>(
@@ -50,6 +57,7 @@ cudaError_t UseParameters(util::Parameters &parameters)
          false,
          "load balancing enabled for graph coloring (true=neighbor_reduce)",
          __FILE__, __LINE__));
+
     // </DONE>
 
     return retval;
@@ -62,7 +70,7 @@ cudaError_t UseParameters(util::Parameters &parameters)
  * @param[in]  parameters    Excution parameters
  * @param[in]  graph         Input graph
 ...
- * @param[in]  target        where to perform the app 
+ * @param[in]  target        where to perform the app
  * \return cudaError_t error message(s), if any
  */
 template <typename GraphT>
@@ -75,9 +83,9 @@ cudaError_t RunTests(
     // </DONE>
     util::Location target)
 {
-    
+
     cudaError_t retval = cudaSuccess;
-       
+
     typedef typename GraphT::VertexT VertexT;
     typedef typename GraphT::ValueT  ValueT;
     typedef typename GraphT::SizeT   SizeT;
@@ -89,7 +97,7 @@ cudaError_t RunTests(
     int  num_runs   = parameters.Get<int >("num-runs");
     std::string validation = parameters.Get<std::string>("validation");
     util::Info info("color", parameters, graph);
-    
+
     util::CpuTimer cpu_timer, total_timer;
     cpu_timer.Start(); total_timer.Start();
 
@@ -107,10 +115,10 @@ cudaError_t RunTests(
     EnactorT enactor;
     GUARD_CU(problem.Init(graph, target));
     GUARD_CU(enactor.Init(problem, target));
-    
+
     cpu_timer.Stop();
     parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
-    
+
     for (int run_num = 0; run_num < num_runs; ++run_num) {
         GUARD_CU(problem.Reset(
             // <TODO> problem specific data if necessary, eg:
@@ -124,7 +132,7 @@ cudaError_t RunTests(
             // </TODO>
             target
         ));
-        
+
         util::PrintMsg("__________________________", !quiet_mode);
 
         cpu_timer.Start();
@@ -142,9 +150,9 @@ cudaError_t RunTests(
             ", #iterations = "
             + std::to_string(enactor.enactor_slices[0]
                 .enactor_stats.iteration), !quiet_mode);
-        
+
         if (validation == "each") {
-            
+
             GUARD_CU(problem.Extract(
                 // <TODO> problem specific data
                 h_colors
@@ -161,7 +169,7 @@ cudaError_t RunTests(
     }
 
     cpu_timer.Start();
-    
+
     GUARD_CU(problem.Extract(
         // <TODO> problem specific data
         h_colors
@@ -279,7 +287,7 @@ cudaError_t RunTests(
 //  * @param[out] distances   Return shortest distance to source per vertex
 //  * @param[out] preds       Return predecessors of each vertex
 //  * \return     double      Return accumulated elapsed times for all runs
- 
+
 // template <
 //     typename VertexT = int,
 //     typename SizeT   = int,

--- a/gunrock/app/color/color_enactor.cuh
+++ b/gunrock/app/color/color_enactor.cuh
@@ -179,7 +179,7 @@ struct ColorIterationLoop : public IterationLoopBase
 	    	SizeT num_neighbors 	= graph.CsrT::GetNeighborListLength(v);
 
 	    	VertexT max = v;    // active max vertex
-		VertexT min = v;    // active min vertex
+		    VertexT min = v;    // active min vertex
 	    	ValueT temp = rand[v];
 
 	    	for (SizeT e = start_edge; e < start_edge + num_neighbors; e++) {
@@ -190,7 +190,7 @@ struct ColorIterationLoop : public IterationLoopBase
 		    if (rand[u] < temp)
 			min = u;
 
-		    printf("Let's see what rand[u] = %f\n", rand[e]);
+		    printf("__GPU__ Let's see what rand[u] = %f\n", rand[e]);
 		    temp = rand[u]; // compare against e-1
 	    	}
 

--- a/gunrock/app/color/color_enactor.cuh
+++ b/gunrock/app/color/color_enactor.cuh
@@ -190,7 +190,7 @@ struct ColorIterationLoop : public IterationLoopBase
 		    if (rand[u] < temp)
 			min = u;
 
-		    printf("__GPU__ Let's see what rand[u] = %f\n", rand[e]);
+		    printf("Let's see what rand[u] = %f\n", rand[u]);
 		    temp = rand[u]; // compare against e-1
 	    	}
 

--- a/gunrock/app/color/color_test.cuh
+++ b/gunrock/app/color/color_test.cuh
@@ -40,17 +40,17 @@ double CPU_Reference(
     bool quiet)
 {
     typedef typename GraphT::SizeT SizeT;
-    
+
     util::CpuTimer cpu_timer;
     cpu_timer.Start();
-    
-    // <TODO> 
+
+    // <TODO>
     // implement CPU reference implementation
     for(SizeT v = 0; v < graph.nodes; ++v) {
         // degrees[v] = graph.row_offsets[v + 1] - graph.row_offsets[v];
     }
     // </TODO>
-    
+
     cpu_timer.Stop();
     float elapsed = cpu_timer.ElapsedMillis();
     return elapsed;
@@ -81,8 +81,9 @@ typename GraphT::SizeT Validate_Results(
     bool quiet = parameters.Get<bool>("quiet");
 
     // <TODO> result validation and display
+    printf("Comparison: <node idx, gunrock, cpu>\n");
     for(SizeT v = 0; v < graph.nodes; ++v) {
-        printf("%d %d %d\n", v, h_colors[v], ref_colors[v]);
+        printf(" %d %d %d\n", v, h_colors[v], ref_colors[v]);
     }
     // </TODO>
 

--- a/gunrock/app/color/color_test.cuh
+++ b/gunrock/app/color/color_test.cuh
@@ -14,6 +14,14 @@
 
 #pragma once
 
+#include <gunrock/util/basic_utils.h>
+#include <gunrock/util/error_utils.cuh>
+#include <gunrock/util/type_limits.cuh>
+#include <gunrock/util/type_enum.cuh>
+
+#include <curand.h>
+#include <curand_kernel.h>
+
 namespace gunrock {
 namespace app {
 // <DONE> change namespace
@@ -35,21 +43,32 @@ namespace color {
  */
 template <typename GraphT>
 double CPU_Reference(
+    util::Parameters &parameters,
     const GraphT &graph,
     typename GraphT::VertexT *colors,
     bool quiet)
 {
-    typedef typename GraphT::SizeT SizeT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef typename GraphT::VertexT VertexT;
+    curandGenerator_t 		gen;
+auto usr_iter = parameters.Get<int>("usr_iter");
+auto seed     = parameters.Get<int>("seed");
 
     util::CpuTimer cpu_timer;
     cpu_timer.Start();
 
-    // <TODO>
-    // implement CPU reference implementation
+    //initialize cpu with same condition, use same variable names as on GPU
+    memset(colors, -1, graph.nodes * sizeof(VertexT));
+
+    util::Array1D<SizeT, float> rand;
+    rand.Allocate(graph.nodes,util::HOST);
+    curandCreateGeneratorHost(&gen,CURAND_RNG_PSEUDO_DEFAULT);
+    curandSetPseudoRandomGeneratorSeed(gen, seed);
+    curandGenerateUniform(gen, rand.GetPointer(util::HOST), graph.nodes);
+
     for(SizeT v = 0; v < graph.nodes; ++v) {
         // degrees[v] = graph.row_offsets[v + 1] - graph.row_offsets[v];
     }
-    // </TODO>
 
     cpu_timer.Stop();
     float elapsed = cpu_timer.ElapsedMillis();

--- a/tests/color/run.sh
+++ b/tests/color/run.sh
@@ -1,1 +1,1 @@
-./bin/test_color_9.0_x86_64 --graph-type=market --graph-file=/media/minh/UStorage/git/color/gunrock/dataset/small/test_cc.mtx --usr_iter=100
+./bin/test_color_9.0_x86_64 --graph-type=market --graph-file=/media/minh/UStorage/git/color/gunrock/dataset/small/test_cc.mtx --seed=1 --usr_iter=1

--- a/tests/color/run.sh
+++ b/tests/color/run.sh
@@ -1,0 +1,1 @@
+./bin/test_color_9.0_x86_64 --graph-type=market --graph-file=/media/minh/UStorage/git/color/gunrock/dataset/small/test_cc.mtx --usr_iter=100

--- a/tests/color/run.sh
+++ b/tests/color/run.sh
@@ -1,1 +1,1 @@
-./bin/test_color_9.0_x86_64 --graph-type=market --graph-file=/media/minh/UStorage/git/color/gunrock/dataset/small/test_cc.mtx --seed=1 --usr_iter=1
+./bin/test_color_9.0_x86_64 --graph-type=market --graph-file=/media/minh/UStorage/git/color/gunrock/dataset/small/test_cc.mtx --seed=123 --usr_iter=1

--- a/tests/color/test_color.cu
+++ b/tests/color/test_color.cu
@@ -73,6 +73,7 @@ struct main_struct
 
 	    util::PrintMsg("__________________________", !quiet);
             float elapsed = app::color::CPU_Reference(
+                parameters,
                 graph.csr(),
                 ref_colors,
                 quiet);

--- a/tests/color/test_color.cu
+++ b/tests/color/test_color.cu
@@ -59,7 +59,7 @@ struct main_struct
         VertexT  *ref_colors = NULL;
 
         bool quick = parameters.Get<bool>("quick");
-	bool color_balance = parameters.Get<bool>("LBCOLOR");
+	      bool color_balance = parameters.Get<bool>("LBCOLOR");
 
         // compute reference CPU SSSP solution for source-distance
         if (!quick)
@@ -70,7 +70,7 @@ struct main_struct
 
             // TODO: problem specific data, e.g.:
             ref_colors = new VertexT[graph.nodes];
-                
+
 	    util::PrintMsg("__________________________", !quiet);
             float elapsed = app::color::CPU_Reference(
                 graph.csr(),
@@ -91,10 +91,10 @@ struct main_struct
 		ref_colors
 	    ](util::Parameters &parameters, GraphT &graph)
             {
-                return app::color::RunTests(parameters, 
-					    graph, 
-					    color_balance, 
-					    ref_colors, 
+                return app::color::RunTests(parameters,
+					    graph,
+					    color_balance,
+					    ref_colors,
 					    util::DEVICE);
             }));
 


### PR DESCRIPTION
iteration flag is " --usr_iter". cpu reference is added, colors init to -1. If there is race condition, gpu and cpu result may not be the same. This only happens on large usr_iter. 

Add in future: omp, try to eliminate race condition when color